### PR TITLE
Preserve whitespace after spelling correction

### DIFF
--- a/tests/test_blob.py
+++ b/tests/test_blob.py
@@ -207,6 +207,9 @@ class SentenceTest(TestCase):
         blob = tb.Sentence("I havv bad speling.")
         assert_true(isinstance(blob.correct(), tb.Sentence))
         assert_equal(blob.correct(), tb.Sentence("I have bad spelling."))
+        blob = tb.Sentence("I havv \ngood speling.")
+        assert_true(isinstance(blob.correct(), tb.Sentence))
+        assert_equal(blob.correct(), tb.Sentence("I have \ngood spelling."))
 
     @attr('requires_internet')
     def test_translate_detects_language_by_default(self):
@@ -784,6 +787,11 @@ is managed by the non-profit Python Software Foundation.'''
                 "reproduce a significant enough slowness."
         blob5 = tb.TextBlob(text)
         assert_equal(blob5.correct(), text)
+        text = "Word list!  :\n" + \
+                "\t* spelling\n" + \
+                "\t* well"
+        blob6 = tb.TextBlob(text)
+        assert_equal(blob6.correct(), text)
 
     def test_parse(self):
         blob = tb.TextBlob("And now for something completely different.")

--- a/textblob/_text.py
+++ b/textblob/_text.py
@@ -1389,6 +1389,8 @@ class Spelling(lazydict):
             return [(w, 1.0)] # I
         if w in PUNCTUATION:
             return [(w, 1.0)] # .?!
+        if w in string.whitespace:
+            return [(w, 1.0)] # \n
         if w.replace(".", "").isdigit():
             return [(w, 1.0)] # 1.5
         candidates = self._known([w]) \

--- a/textblob/blob.py
+++ b/textblob/blob.py
@@ -23,7 +23,6 @@ Example usage: ::
 from __future__ import unicode_literals, absolute_import
 import sys
 import json
-import string as pystring
 from collections import defaultdict
 from itertools import chain
 
@@ -544,27 +543,10 @@ class BaseBlob(StringlikeMixin, BlobComparableMixin):
 
         :rtype: BaseBlob
         '''
-        def join_tokens(tokens):
-            ret = ''
-            # Separate each token with a space unless the token is a punctuation
-            for i, word in enumerate(tokens):
-                # Avoid an extra space at the beginning
-                if word in pystring.punctuation or i == 0:
-                    ret = ''.join([ret, word])
-                else:
-                    ret = ' '.join([ret, word])
-            return ret
-
-        def correct_sentence(sent):
-            '''Spell-corrects a sentence.'''
-            word_tok = WordTokenizer()
-            corrected = (Word(w).correct() for w in word_tok.tokenize(sent,
-                                                                include_punc=True))
-            return join_tokens(corrected)
-        # First tokenize to sentence, then correct words within each sentence.
-        sentence_tok = SentenceTokenizer()
-        sentences = sentence_tok.itokenize(self.raw)
-        ret = join_tokens([correct_sentence(sent) for sent in sentences])
+        # regex matches: contraction or word or punctuation or whitespace
+        tokens = nltk.tokenize.regexp_tokenize(self.raw, "\w*('\w*)+|\w+|[^\w\s]|\s")
+        corrected = (Word(w).correct() for w in tokens)
+        ret = ''.join(corrected)
         return self.__class__(ret)
 
     def _cmpkey(self):


### PR DESCRIPTION
I forked to solve https://github.com/sloria/TextBlob/issues/12
There are a few changes beyond exactly what was stated in the issue.
Most of these simplify the implentation and none break tests.
I believe that all of the changed behavior is:
- Spelling.suggest(w)  will return w if w is a whitespace character
- correct() does not remove whitespace from the beginning.
- correct() preserves all whitespace including new lines, double spaces, and tabs
- contractions are corrected as a whole.  e.g. "won't" to "wont" instead of "won't" to "wo not"
- punctuation separates words.  e.g. "speling.bee" to "spelling.bee" instead of "speling.bee" to "speling.bee"

If you're interested in using this, but want some stuff tweaked, please let me know and I'll try to accommodate you.
