### PR TITLE
Fix docstring to download the corpora

### DIFF
--- a/textblob/exceptions.py
+++ b/textblob/exceptions.py
@@ -5,7 +5,7 @@ Looks like you are missing some required data for this feature.
 
 To download the necessary data, simply run
 
-    curl https://raw.github.com/sloria/TextBlob/master/download_corpora.py | python
+    curl https://raw.githubusercontent.com/sloria/TextBlob/dev/textblob/download_corpora.py | python
 
 Or use the NLTK downloader to download the missing data: http://nltk.org/data.html
 If this doesn't fix the problem, file an issue at https://github.com/sloria/TextBlob/issues.


### PR DESCRIPTION
The URL for the the download_corpora seems to have changed from https://raw.github.com/sloria/TextBlob/master/download_corpora.py to https://raw.githubusercontent.com/sloria/TextBlob/dev/textblob/download_corpora.py
