### PR TITLE
Fix for different local Google Translate results in unit tests

### DIFF
--- a/tests/test_blob.py
+++ b/tests/test_blob.py
@@ -871,7 +871,8 @@ class WordTest(TestCase):
 
     @attr('requires_internet')
     def test_translate_without_from_lang(self):
-        assert_true(tb.Word('hola').translate() in (tb.Word('hello'), tb.Word('hi there')))
+        valid_translations = (tb.Word('hello'), tb.Word('hi there'))
+        assert_true(tb.Word('hola').translate() in valid_translations)
 
     @attr('requires_internet')
     def test_detect_language(self):


### PR DESCRIPTION
Just a tiny change that makes it pass.
