### PR TITLE
Corrects issue #83 (erroneous whitespace) using JSON API for Google Translate

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -16,3 +16,4 @@ Contributors (chronological)
 - David Karesh `@davidnk <https://github.com/davidnk>`_
 - Evan Dempsey `@evandempsey <https://github.com/evandempsey>`_
 - Wesley Childs `@mrchilds <https://github.com/mrchilds>`_
+- Jeff Schnurr '@jschnurr <https://github.com/jschnurr>'

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -18,43 +18,28 @@ class TestTranslator(unittest.TestCase):
 
     @mock.patch('textblob.translate.Translator._get_json5')
     def test_translate(self, mock_get_json5):
-        mock_get_json5.return_value = unicode('[[["Esta es una frase","This is a '
-            'sentence","",""]],,"en",,[["Esta es una",[1],true,false,374,0,3,0]'
-            ',["frase",[2],true,false,470,3,4,0]],[["This is a",1,[["Esta es'
-            ' una",374,true,false],["Se trata de una",6,true,false],'
-            '["Este es un",0,true,false],["Se trata de un",0,true,false],'
-            '["Esto es un",0,true,false]],[[0,9]],"This is a sentence"],'
-            '["sentence",2,[["frase",470,true,false],["sentencia",6,true,false],'
-            '["oraci\xf3n",0,true,false],["pena",0,true,false],["condena"'
-            ',0,true,false]],[[10,18]],""]],,,[["en"]],29]')
+        mock_get_json5.return_value = unicode('{"sentences":[{"trans":'
+                                        '"Esta es una frase.","orig":'
+                                        '"This is a sentence.","translit":"",'
+                                        '"src_translit":""}],"src":"en",'
+                                        '"server_time":2}')
         t = self.translator.translate(self.sentence, to_lang="es")
-        assert_equal(t, "Esta es una frase")
+        assert_equal(t, "Esta es una frase.")
         assert_true(mock_get_json5.called_once)
 
     @mock.patch('textblob.translate.Translator._get_json5')
     def test_detect_parses_json5(self, mock_get_json5):
-        mock_get_json5.return_value = unicode('[[["This is a sentence",'
-            '"This is a sentence","",""]],,"en",,,,,,[["en"]],4]')
+        mock_get_json5.return_value = unicode('{"sentences":[{"trans":'
+                                        '"This is a sentence.","orig":'
+                                        '"This is a sentence.","translit":"",'
+                                        '"src_translit":""}],"src":"en",'
+                                        '"server_time":1}')
         lang = self.translator.detect(self.sentence)
         assert_equal(lang, "en")
-        mock_get_json5.return_value = unicode('[[["Hello","Hola","",""]],[["interjection",'
-                                        '["Hello!","Hi!","Hey!","Hullo!","Hallo!",'
-                                        '"Hoy!","Hail!"],[["Hello!",["\xa1Hola!","'
-                                        '\xa1Caramba!","\xa1Oiga!","\xa1Diga!","'
-                                        '\xa1Bueno!","\xa1Vale!"],,0.39160562],'
-                                        '["Hi!",["\xa1Hola!"],,0.24506053],'
-                                        '["Hey!",["\xa1Hola!","\xa1Eh!"],,0.038173068]'
-                                        ',["Hullo!",["\xa1Hola!","\xa1Caramba!",'
-                                        '"\xa1Oiga!","\xa1Diga!","\xa1Bueno!",'
-                                        '"\xa1Al\xf3!"]],["Hallo!",["\xa1Hola!",'
-                                        '"\xa1Caramba!","\xa1Oiga!","\xa1Bueno!"]],'
-                                        '["Hoy!",["\xa1Eh!","\xa1Hola!"]],["Hail!",'
-                                        '["\xa1Salve!","\xa1Hola!"]]],"\xa1Hola!",9]],'
-                                        '"es",,[["Hello",[1],true,false,783,0,1,0]],'
-                                        '[["Hola",1,[["Hello",783,true,false],'
-                                        '["Hi",214,true,false],["Hola",1,true,false],'
-                                        '["Hey",0,true,false],["Welcome",0,true,false]],'
-                                        '[[0,4]],"Hola"]],,,[],4]')
+        mock_get_json5.return_value = unicode('{"sentences":[{"trans":'
+                                        '"Hello","orig":"Hola",'
+                                        '"translit":"","src_translit":""}],'
+                                        '"src":"es","server_time":2}')
         lang2 = self.translator.detect("Hola")
         assert_equal(lang2, "es")
 
@@ -71,6 +56,12 @@ class TestTranslator(unittest.TestCase):
         assert_equal(lang2, "bg")
         lang3 = self.translator.detect(unicode("Избранная статья"))
         assert_equal(lang3, "ru")
+
+    @attr("requires internet")
+    def test_translate_spaces(self):
+        es_text = u"Hola, me llamo Adrián! Cómo estás? Yo bien"
+        to_en = self.translator.translate(es_text, from_lang="es", to_lang="en")
+        assert_equal(to_en, "Hello, my name is Adrian! How are you? I'm fine")
 
     @attr("requires_internet")
     def test_translate_text(self):
@@ -102,7 +93,9 @@ class TestTranslator(unittest.TestCase):
         assert_raises(TranslatorError, lambda: self.translator.detect('fo'))
 
     def test_get_language_from_json5(self):
-        json5 = '[[["This is a sentence.","This is a sentence.","",""]],,"en",,,,,,[["en"]],0]'
+        json5 = ('{"sentences":[{"trans":"This is a sentence.",'
+                 '"orig":"This is a sentence.","translit":"",'
+                 '"src_translit":""}],"src":"en","server_time":1}')
         lang = self.translator._get_language_from_json5(json5)
         assert_equal(lang, "en")
 

--- a/textblob/translate.py
+++ b/textblob/translate.py
@@ -6,6 +6,7 @@ Adapted from Terry Yin's google-translate-python.
 Language detection added by Steven Loria.
 """
 from __future__ import absolute_import
+import json
 import re
 import codecs
 from textblob.compat import PY2, request, urlencode
@@ -26,17 +27,6 @@ class Translator(object):
         u'es'
     """
 
-    string_pattern = r"\"(([^\"\\]|\\.)*)\""
-    translation_pattern = re.compile(
-                        r"\,?\["
-                           + string_pattern + r"\,"
-                           + string_pattern + r"\,"
-                           + string_pattern + r"\,"
-                           + string_pattern
-                        + r"\]")
-    detection_pattern = re.compile(
-        r".*?\,\"([a-z]{2}(\-\w{2})?)\"\,.*?", flags=re.S)
-
     url = "http://translate.google.com/translate_a/t"
 
     headers = {'User-Agent': ('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8) '
@@ -46,7 +36,7 @@ class Translator(object):
         """Translate the source text from one language to another."""
         if PY2:
             source = source.encode('utf-8')
-        data = {"client": "t", "ie": "UTF-8", "oe": "UTF-8",
+        data = {"client": "p", "ie": "UTF-8", "oe": "UTF-8",
                 "sl": from_lang, "tl": to_lang, "text": source}
         json5 = self._get_json5(self.url, host=host, type_=type_, data=data)
         return self._get_translation_from_json5(json5)
@@ -57,26 +47,22 @@ class Translator(object):
             source = source.encode('utf-8')
         if len(source) < 3:
             raise TranslatorError('Must provide a string with at least 3 characters.')
-        data = {"client": "t", "ie": "UTF-8", "oe": "UTF-8", "text": source}
+        data = {"client": "p", "ie": "UTF-8", "oe": "UTF-8", "text": source}
         json5 = self._get_json5(self.url, host=host, type_=type_, data=data)
         lang = self._get_language_from_json5(json5)
         return lang
 
     def _get_language_from_json5(self, content):
-        match = self.detection_pattern.match(content)
-        if not match:
-            return None
-        return match.group(1)
+        json_data = json.loads(content)
+        if 'src' in json_data:
+            return json_data['src']
+        return None
 
     def _get_translation_from_json5(self, content):
         result = u""
-        pos = 2
-        while True:
-            m = self.translation_pattern.match(content, pos)
-            if not m:
-                break
-            result += m.group(1)
-            pos = m.end()
+        json_data = json.loads(content)
+        if 'sentences' in json_data:
+            result = ''.join([s['trans'] for s in json_data['sentences']])
         return _unescape(result)
 
     def _get_json5(self, url, host=None, type_=None, data=None):


### PR DESCRIPTION
In the example cited in the issue report, whitespace is erroneously provided by the API.  The JSON response to the same query does not exhibit the symptom.  Converted translate to use JSON responses.