### PR TITLE
Corrects issue #85 - from_lang defaults to None

### DIFF
--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -63,6 +63,12 @@ class TestTranslator(unittest.TestCase):
         to_en = self.translator.translate(es_text, from_lang="es", to_lang="en")
         assert_equal(to_en, "Hello, my name is Adrian! How are you? I'm fine")
 
+    @attr("requires internet")
+    def test_translate_missing_from_language_auto_detects(self):
+        text = u"Ich besorge das Bier"
+        translated = self.translator.translate(text, to_lang="en")
+        assert_equal(translated, u"I'll get the beer")
+
     @attr("requires_internet")
     def test_translate_text(self):
         text = "This is a sentence."

--- a/textblob/translate.py
+++ b/textblob/translate.py
@@ -32,7 +32,7 @@ class Translator(object):
     headers = {'User-Agent': ('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8) '
             'AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.168 Safari/535.19')}
 
-    def translate(self, source, from_lang='en', to_lang='en', host=None, type_=None):
+    def translate(self, source, from_lang=None, to_lang='en', host=None, type_=None):
         """Translate the source text from one language to another."""
         if PY2:
             source = source.encode('utf-8')


### PR DESCRIPTION
```python
>>>from textblob.translate import Translator
>>>t = Translator()

>>>t.translate('hello', to_lang='fr')
u'Bonjour'

>>> t.translate('hola', from_lang=None, to_lang='fr')
u'Bonjour'

>>>t.translate('hola', to_lang='fr')
u'Bonjour'
```