### PR TITLE
Fix #76 - when translation fails, raise TranslatorError.

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -221,6 +221,7 @@ TextBlobs can be translated between languages.
     TextBlob("Simple es mejor que complejo.")
 
 If no source language is specified, TextBlob will attempt to detect the language. You can specify the source language explicitly, like so.
+Raises TranslatorError if the TextBlob cannot be translated into the requested language.
 
 .. doctest::
 


### PR DESCRIPTION
If Google Translate API returns 1) malformed JSON or 2) the same 'original' and 'translated' strings, raise an error indicating the translation failed.
```python
>>> translator.translate(u'        Ꭰ Ꭱ Ꭲ Ꭳ Ꭴ Ꭵ     ', to_lang='en')
  File "/dev/TextBlob/textblob/translate.py", line 45, in translate
    raise TranslatorError('Translation API returned an invalid result.')
textblob.exceptions.TranslatorError: Translation API returned an invalid result.
```
