### PR TITLE
Explain the new "unchanged" text error in the CHANGELOG

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,7 +20,7 @@ Bug fixes:
 
 Changes:
 
-- When translation fails, raise a ``TranslationError`` (:issue:`76`). Thanks :user:`jschnurr`.
+- Unchanged text is now considered a translation error. Raises ``NotTranslated`` (:issue:`76`). Thanks :user:`jschnurr`.
 
 Bug fixes:
 


### PR DESCRIPTION
This was a bit backwards incompatible for us.