### PR TITLE
Fixed failing test by correcting translated Spanish result.

### DIFF
--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -85,7 +85,7 @@ class TestTranslator(unittest.TestCase):
     def test_translate_text(self):
         text = "This is a sentence."
         translated = self.translator.translate(text, to_lang="es")
-        assert_equal(translated, "Esta es una frase.")
+        assert_equal(translated, "Esta es una oración.")
         es_text = "Esta es una frase."
         to_en = self.translator.translate(es_text, from_lang="es", to_lang="en")
         assert_equal(to_en, "This is a sentence.")


### PR DESCRIPTION
It's not clear to me how this test case ever worked; perhaps the API was translating this string differently in the past.  In any case, the Google Translate API today translates "This is a sentence." into Spanish as "Esta es una oración.", and this PR updates the test to match.