### PR TITLE
Fixes translations with new Google Translate API

### DIFF
--- a/tests/test_blob.py
+++ b/tests/test_blob.py
@@ -219,14 +219,8 @@ class SentenceTest(TestCase):
         assert_true(isinstance(blob.correct(), tb.Sentence))
         assert_equal(blob.correct(), tb.Sentence("I have \ngood spelling."))
 
-    @mock.patch('textblob.translate.Translator._get_translation_from_json5')
-    @mock.patch('textblob.translate.Translator._get_language_from_json5')
-    @mock.patch('textblob.translate.Translator._get_json5')
     @mock.patch('textblob.translate.Translator.detect')
-    def test_translate_detects_language_by_default(self, mock_detect,
-            mock_get_json5, mock_get_language, mock_get_translation):
-        mock_get_language.return_value = 'ar'
-        mock_get_translation.return_value = 'Fully sovereign'
+    def test_translate_detects_language_by_default(self, mock_detect):
         text = unicode("ذات سيادة كاملة")
         blob = tb.TextBlob(text)
         assert_true(mock_detect.called_once_with(text))

--- a/textblob/translate.py
+++ b/textblob/translate.py
@@ -29,66 +29,68 @@ class Translator(object):
 
     url = "http://translate.google.com/translate_a/t"
 
-    headers = {'User-Agent': ('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8) '
-            'AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.168 Safari/535.19')}
+    headers = {'Connection': 'keep-alive',
+               'Accept': '*/*',
+               'User-Agent': ('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8) '
+                              'AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18'
+                              '.0.1025.168 Safari/535.19')
+    }
 
     def translate(self, source, from_lang=None, to_lang='en', host=None, type_=None):
         """Translate the source text from one language to another."""
-        if PY2:
-            source = source.encode('utf-8')
-        data = {"client": "p", "ie": "UTF-8", "oe": "UTF-8",
-                "sl": from_lang, "tl": to_lang, "text": source}
-        json5 = self._get_json5(self.url, host=host, type_=type_, data=data)
-        if self._translation_successful(json5):
-            return self._get_translation_from_json5(json5)
+        result = self._api_request(self.url, source=source, from_lang=from_lang,
+                                   to_lang=to_lang, host=host, type_=type_)
+        if self._valid(result):
+            data = json.loads(result)
+            if isinstance(data, list):
+                data = data[0]
+            elif isinstance(data, basestring):
+                data = data
+
+            if data.strip() == source.strip():
+                raise NotTranslated('Translation API returned the input string unchanged.')
+
+            return _unescape(data)
+
         else:
-            raise NotTranslated('Translation API returned the input string unchanged.')
+            raise TranslatorError('Translation API returned an unexpected result.')
 
     def detect(self, source, host=None, type_=None):
         """Detect the source text's language."""
-        if PY2:
-            source = source.encode('utf-8')
         if len(source) < 3:
             raise TranslatorError('Must provide a string with at least 3 characters.')
-        data = {"client": "p", "ie": "UTF-8", "oe": "UTF-8", "text": source}
-        json5 = self._get_json5(self.url, host=host, type_=type_, data=data)
-        lang = self._get_language_from_json5(json5)
-        return lang
 
-    def _get_language_from_json5(self, content):
-        json_data = json.loads(content)
-        if 'src' in json_data:
-            return json_data['src']
-        return None
+        result = self._api_request(self.url, source=source, from_lang='auto',
+                                   to_lang='en', host=host, type_=type_)
+        if self._valid(result):
+            data = json.loads(result)
+            return data[1]
+        else:
+            raise TranslatorError('Translation API could not detect language.')
 
-    def _get_translation_from_json5(self, content):
-        result = u""
-        json_data = json.loads(content)
-        if 'sentences' in json_data:
-            result = ''.join([s['trans'] for s in json_data['sentences']])
-        return _unescape(result)
-
-    def _translation_successful(self, content):
-        """Validate API returned expected schema, and that the translated text
-        is different than the original string.
+    def _valid(self, content):
+        """Validate API returned valid JSON with expected schema.
         """
         json_data = json.loads(content)
-        result = False
-        if 'sentences' in json_data:
-            response = json_data['sentences'][0]
-            if 'orig' in response and 'trans' in response:
-                result = response['orig'] != response['trans']
-        return result
+        return ((isinstance(json_data, list) and len(json_data) == 2) or
+                (isinstance(json_data, basestring)))
 
-    def _get_json5(self, url, host=None, type_=None, data=None):
+    def _api_request(self, url=url, source=None, from_lang=None, to_lang=None,
+                     host=None, type_=None):
+        if PY2:
+            source = source.encode('utf-8')
+
+        data = {"client": "p", "ie": "UTF-8", "oe": "UTF-8",
+                "sl": from_lang or 'auto', "tl": to_lang, "text": source}
         encoded_data = urlencode(data).encode('utf-8')
         req = request.Request(url=url, headers=self.headers, data=encoded_data)
+
         if host or type_:
             req.set_proxy(host=host, type=type_)
+
         resp = request.urlopen(req)
         content = resp.read()
         return content.decode('utf-8')
-
 
 def _unescape(text):
     """Unescape unicode character codes within a string.

--- a/textblob/translate.py
+++ b/textblob/translate.py
@@ -9,9 +9,8 @@ from __future__ import absolute_import
 import json
 import re
 import codecs
-from textblob.compat import PY2, request, urlencode
+from textblob.compat import PY2, request, urlencode, basestring
 from textblob.exceptions import TranslatorError, NotTranslated
-
 
 class Translator(object):
 


### PR DESCRIPTION
Resolve #115.  Google Translate API changed on 15-Feb-2016 - now returns basestrings and 2-element lists, and requires that headers include Accept and Connection parameters.

Includes API changes and associated refactoring, and changes to tests.

Public method signatures stay the same, and all tests return the same values as before.