### PR TITLE
Update translator with changes in Google's API

### DIFF
--- a/tests/test_blob.py
+++ b/tests/test_blob.py
@@ -219,17 +219,14 @@ class SentenceTest(TestCase):
         assert_true(isinstance(blob.correct(), tb.Sentence))
         assert_equal(blob.correct(), tb.Sentence("I have \ngood spelling."))
 
-    @mock.patch('textblob.translate.Translator._get_translation_from_json5')
-    @mock.patch('textblob.translate.Translator._get_language_from_json5')
-    @mock.patch('textblob.translate.Translator._get_json5')
-    @mock.patch('textblob.translate.Translator.detect')
-    def test_translate_detects_language_by_default(self, mock_detect,
-            mock_get_json5, mock_get_language, mock_get_translation):
-        mock_get_language.return_value = 'ar'
-        mock_get_translation.return_value = 'Fully sovereign'
+
+    @mock.patch('textblob.translate.Translator.translate')
+    def test_translate_detects_language_by_default(self, mock_translate):
         text = unicode("ذات سيادة كاملة")
+        mock_translate.return_value = "With full sovereignty"
         blob = tb.TextBlob(text)
-        assert_true(mock_detect.called_once_with(text))
+        blob.translate()
+        assert_true(mock_translate.called_once_with(text, from_lang='auto'))
 
 
 class TextBlobTest(TestCase):

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -1,87 +1,93 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
+
 import unittest
+import re
 
 from nose.plugins.attrib import attr
 from nose.tools import *  # noqa (PEP8 asserts)
 import mock
 
 from textblob.translate import Translator, _unescape
-from textblob.compat import unicode
 from textblob.exceptions import TranslatorError, NotTranslated
 
+
 class TestTranslator(unittest.TestCase):
+
+    """Unit tests with external requests mocked out."""
 
     def setUp(self):
         self.translator = Translator()
         self.sentence = "This is a sentence."
 
-    @mock.patch('textblob.translate.Translator._get_json5')
-    def test_translate(self, mock_get_json5):
-        mock_get_json5.return_value = unicode('{"sentences":[{"trans":'
-                                        '"Esta es una frase.","orig":'
-                                        '"This is a sentence.","translit":"",'
-                                        '"src_translit":""}],"src":"en",'
-                                        '"server_time":2}')
+    @mock.patch('textblob.translate.Translator._request')
+    def test_translate(self, mock_request):
+        mock_request.return_value = '["Esta es una frase.","en"]'
         t = self.translator.translate(self.sentence, to_lang="es")
         assert_equal(t, "Esta es una frase.")
-        assert_true(mock_get_json5.called_once)
+        assert_true(mock_request.called_once)
 
-    @mock.patch('textblob.translate.Translator._get_json5')
-    def test_detect_parses_json5(self, mock_get_json5):
-        mock_get_json5.return_value = unicode('{"sentences":[{"trans":'
-                                        '"This is a sentence.","orig":'
-                                        '"This is a sentence.","translit":"",'
-                                        '"src_translit":""}],"src":"en",'
-                                        '"server_time":1}')
-        lang = self.translator.detect(self.sentence)
-        assert_equal(lang, "en")
-        mock_get_json5.return_value = unicode('{"sentences":[{"trans":'
-                                        '"Hello","orig":"Hola",'
-                                        '"translit":"","src_translit":""}],'
-                                        '"src":"es","server_time":2}')
-        lang2 = self.translator.detect("Hola")
-        assert_equal(lang2, "es")
+    @mock.patch('textblob.translate.Translator._request')
+    def test_failed_translation_raises_not_translated(self, mock_request):
+        failed_responses = ['""', '[""]', '["",""]', '" n0tv&l1d "']
+        mock_request.side_effect = failed_responses
+        text = ' n0tv&l1d '
+        for response in failed_responses:
+            assert_raises(NotTranslated,
+                          self.translator.translate, text, to_lang="es")
+        assert_equal(mock_request.call_count, len(failed_responses))
 
-    @mock.patch('textblob.translate.Translator._get_json5')
-    def test_failed_translation_raises_not_translated(self, mock_get_json5):
-        mock_get_json5.return_value = unicode('{"sentences":[{"trans":'
-                                        '"n0tv\\u0026l1d","orig":'
-                                        '"n0tv\\u0026l1d","translit":"",'
-                                        '"src_translit":""}],'
-                                        '"src":"en","server_time":2}')
-        text = unicode(' n0tv&l1d ')
-        assert_raises(NotTranslated,
-                      self.translator.translate, text, to_lang="es")
-        assert_true(mock_get_json5.called_once)
+    @mock.patch("textblob.translate.Translator._request")
+    def test_tk_parameter_included_in_requests(self, mock_request):
+        mock_request.return_value = '["Esta es una frase.","en"]'
+        self.translator.translate(self.sentence, to_lang="es")
+        assert_true(mock_request.called_once)
+        args, kwargs = mock_request.call_args
+        tk = kwargs['data']['tk']
+        assert_true(re.match(r'^\d+\.\d+$', tk))
 
-    @attr("requires_internet")
+    @mock.patch('textblob.translate.Translator._request')
+    def test_detect(self, mock_request):
+        mock_request.return_value = '["Esta es una frase.","en"]'
+        language = self.translator.detect(self.sentence)
+        assert_equal(language, "en")
+        assert_true(mock_request.called_once)
+
+    def test_detect_requires_more_than_two_characters(self):
+        assert_raises(TranslatorError, lambda: self.translator.detect('f'))
+        assert_raises(TranslatorError, lambda: self.translator.detect('fo'))
+
+
+@attr("requires_internet")
+class TestTranslatorIntegration(unittest.TestCase):
+
+    """Integration tests that actually call the translation API."""
+
+    def setUp(self):
+        self.translator = Translator()
+
     def test_detect(self):
         assert_equal(self.translator.detect('Hola'), "es")
         assert_equal(self.translator.detect('Hello'), "en")
 
-    @attr('requires_internet')
     def test_detect_non_ascii(self):
-        lang = self.translator.detect(unicode("关于中文维基百科"))
+        lang = self.translator.detect("关于中文维基百科")
         assert_equal(lang, 'zh-CN')
-        lang2 = self.translator.detect(unicode("известен още с псевдонимите"))
+        lang2 = self.translator.detect("известен още с псевдонимите")
         assert_equal(lang2, "bg")
-        lang3 = self.translator.detect(unicode("Избранная статья"))
+        lang3 = self.translator.detect("Избранная статья")
         assert_equal(lang3, "ru")
 
-    @attr("requires_internet")
     def test_translate_spaces(self):
-        es_text = u"Hola, me llamo Adrián! Cómo estás? Yo bien"
+        es_text = "Hola, me llamo Adrián! Cómo estás? Yo bien"
         to_en = self.translator.translate(es_text, from_lang="es", to_lang="en")
         assert_equal(to_en, "Hello, my name is Adrian! How are you? I am good")
 
-    @attr("requires_internet")
     def test_translate_missing_from_language_auto_detects(self):
-        text = u"Ich besorge das Bier"
+        text = "Ich besorge das Bier"
         translated = self.translator.translate(text, to_lang="en")
-        assert_equal(translated, u"I'll get the beer")
+        assert_equal(translated, "I'll get the beer")
 
-    @attr("requires_internet")
     def test_translate_text(self):
         text = "This is a sentence."
         translated = self.translator.translate(text, to_lang="es")
@@ -90,39 +96,26 @@ class TestTranslator(unittest.TestCase):
         to_en = self.translator.translate(es_text, from_lang="es", to_lang="en")
         assert_equal(to_en, "This is a sentence.")
 
-    @attr("requires_internet")
     def test_translate_non_ascii(self):
-        text = unicode("ذات سيادة كاملة")
+        text = "ذات سيادة كاملة"
         translated = self.translator.translate(text, from_lang='ar', to_lang='en')
         assert_equal(translated, "With full sovereignty")
 
-        text2 = unicode("美丽优于丑陋")
+        text2 = "美丽优于丑陋"
         translated = self.translator.translate(text2, from_lang="zh-CN", to_lang='en')
         assert_equal(translated, "Beautiful is better than ugly")
 
-    @attr("requires_internet")
-    @mock.patch('textblob.translate.Translator._translation_successful')
-    def test_translate_unicode_escape(self, trans_success_mock):
-        trans_success_mock.return_value = True
+    @mock.patch('textblob.translate.Translator._validate_translation', mock.MagicMock())
+    def test_translate_unicode_escape(self):
         text = "Jenner & Block LLP"
         translated = self.translator.translate(text, from_lang="en", to_lang="en")
         assert_equal(translated, "Jenner & Block LLP")
-
-    def test_detect_requires_more_than_two_characters(self):
-        assert_raises(TranslatorError, lambda: self.translator.detect('f'))
-        assert_raises(TranslatorError, lambda: self.translator.detect('fo'))
-
-    def test_get_language_from_json5(self):
-        json5 = ('{"sentences":[{"trans":"This is a sentence.",'
-                 '"orig":"This is a sentence.","translit":"",'
-                 '"src_translit":""}],"src":"en","server_time":1}')
-        lang = self.translator._get_language_from_json5(json5)
-        assert_equal(lang, "en")
 
 
 def test_unescape():
     assert_equal(_unescape('and'), 'and')
     assert_equal(_unescape('\u0026'), '&')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/textblob/blob.py
+++ b/textblob/blob.py
@@ -91,16 +91,14 @@ class Word(unicode):
         '''Return the plural version of the word as a string.'''
         return Word(_pluralize(self.string))
 
-    def translate(self, from_lang=None, to="en"):
+    def translate(self, from_lang='auto', to="en"):
         '''Translate the word to another language using Google's
         Translate API.
 
         .. versionadded:: 0.5.0
         '''
-        if from_lang is None:
-            from_lang = self.translator.detect(self.string)
         return self.translator.translate(self.string,
-                                        from_lang=from_lang, to_lang=to)
+                                         from_lang=from_lang, to_lang=to)
 
     def detect_language(self):
         '''Detect the word's language using Google's Translate API.
@@ -480,7 +478,7 @@ class BaseBlob(StringlikeMixin, BlobComparableMixin):
                             for i in range(len(self.words) - n + 1)]
         return grams
 
-    def translate(self, from_lang=None, to="en"):
+    def translate(self, from_lang="auto", to="en"):
         """Translate the blob to another language.
         Uses the Google Translate API. Returns a new TextBlob.
 
@@ -503,10 +501,8 @@ class BaseBlob(StringlikeMixin, BlobComparableMixin):
         :param str to: Language to translate to.
         :rtype: :class:`BaseBlob <BaseBlob>`
         """
-        if from_lang is None:
-            from_lang = self.translator.detect(self.string)
         return self.__class__(self.translator.translate(self.raw,
-                        from_lang=from_lang, to_lang=to))
+                              from_lang=from_lang, to_lang=to))
 
     def detect_language(self):
         """Detect the blob's language using the Google Translate API.

--- a/textblob/translate.py
+++ b/textblob/translate.py
@@ -46,10 +46,11 @@ class Translator(object):
                 "sl": from_lang, "tl": to_lang, "text": source}
         response = self._request(self.url, host=host, type_=type_, data=data)
         result = json.loads(response)
-        try:
-            result, _ = json.loads(response)
-        except ValueError:
-            pass
+        if isinstance(result, list):
+            try:
+                result = result[0]  # ignore detected language
+            except IndexError:
+                pass
         self._validate_translation(source, result)
         return result
 
@@ -96,15 +97,15 @@ def _unescape(text):
     return re.sub(pattern, decode, text)
 
 
-def _calculate_tk(a):
+def _calculate_tk(source):
     """Reverse engineered cross-site request protection."""
     # Source: https://github.com/soimort/translate-shell/issues/94#issuecomment-165433715
     b = int(time.time() / 3600)
 
     if PY2:
-        d = map(ord, a)
+        d = map(ord, source)
     else:
-        d = a.encode('utf-8')
+        d = source.encode('utf-8')
 
     def RL(a, b):
         for c in range(0, len(b) - 2, 3):
@@ -122,5 +123,5 @@ def _calculate_tk(a):
     a = a if a >= 0 else ((a & 2147483647) + 2147483648)
     a %= pow(10, 6)
 
-    tk = '{:d}.{:d}'.format(a, a ^ b)
+    tk = '{0:d}.{1:d}'.format(a, a ^ b)
     return tk

--- a/textblob/translate.py
+++ b/textblob/translate.py
@@ -33,8 +33,13 @@ class Translator(object):
 
     url = "http://translate.google.com/translate_a/t"
 
-    headers = {'User-Agent': ('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8) '
-               'AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.168 Safari/535.19')}
+    headers = {
+        'Accept': '*/*',
+        'Connection': 'keep-alive',
+        'User-Agent': (
+            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8) '
+            'AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.168 Safari/535.19')
+    }
 
     def translate(self, source, from_lang='auto', to_lang='en', host=None, type_=None):
         """Translate the source text from one language to another."""


### PR DESCRIPTION
As commented in #115 

This PR fixes the translator to make it work with the new format in the response and also send a new parameter to avoid 403 Forbidden responses. This has been reverse engineered by the people at https://github.com/soimort/translate-shell/issues/94 

There's also some minimal refactors in the tests and improvements in the translation when detecting the source language.