### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -186,7 +186,7 @@ Bug fixes:
 - New ``Blobber`` class for creating TextBlobs that share the same tagger, tokenizer, and np_extractor.
 - Add ``ngrams`` method.
 - `Backwards-incompatible`: ``TextBlob.json()`` is now a method, not a property. This allows you to pass arguments (the same that you would pass to ``json.dumps()``).
-- New home for documentation: https://textblob.readthedocs.org/
+- New home for documentation: https://textblob.readthedocs.io/
 - Add parameter for cleaning HTML markup from text.
 - Minor improvement to word tokenization.
 - Updated NLTK.

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ TextBlob: Simplified Text Processing
     :target: https://travis-ci.org/sloria/TextBlob
     :alt: Travis-CI
 
-Homepage: `https://textblob.readthedocs.org/ <https://textblob.readthedocs.org/>`_
+Homepage: `https://textblob.readthedocs.io/ <https://textblob.readthedocs.io/>`_
 
 `TextBlob` is a Python (2 and 3) library for processing textual data. It provides a simple API for diving into common natural language processing (NLP) tasks such as part-of-speech tagging, noun phrase extraction, sentiment analysis, classification, translation, and more.
 
@@ -76,13 +76,13 @@ Examples
 
 See more examples at the `Quickstart guide`_.
 
-.. _`Quickstart guide`: https://textblob.readthedocs.org/en/latest/quickstart.html#quickstart
+.. _`Quickstart guide`: https://textblob.readthedocs.io/en/latest/quickstart.html#quickstart
 
 
 Documentation
 -------------
 
-Full documentation is available at https://textblob.readthedocs.org/.
+Full documentation is available at https://textblob.readthedocs.io/.
 
 Requirements
 ------------
@@ -92,8 +92,8 @@ Requirements
 Project Links
 -------------
 
-- Docs: https://textblob.readthedocs.org/
-- Changelog: https://textblob.readthedocs.org/en/latest/changelog.html
+- Docs: https://textblob.readthedocs.io/
+- Changelog: https://textblob.readthedocs.io/en/latest/changelog.html
 - PyPI: https://pypi.python.org/pypi/TextBlob
 - Issues: https://github.com/sloria/TextBlob/issues
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.