### PR TITLE
Attempting to fix slow NaiveBayes

### DIFF
--- a/textblob/classifiers.py
+++ b/textblob/classifiers.py
@@ -80,7 +80,7 @@ def basic_extractor(document, train_set):
     """
 
     try:
-        el_zero = iter(train_set).next() #Infer input from first element.
+        el_zero = next(iter(train_set)) #Infer input from first element.
     except StopIteration:
         return {}
     if isinstance(el_zero, basestring):

--- a/textblob/classifiers.py
+++ b/textblob/classifiers.py
@@ -83,11 +83,11 @@ def basic_extractor(document, train_set):
         el_zero = iter(train_set).next() #Infer input from first element.
     except StopIteration:
         return {}
-    if isinstance(el_zero, str):
+    if isinstance(el_zero, basestring):
         word_features = [w for w in chain([el_zero],train_set)]
     else:
         try:
-            assert(isinstance(el_zero[0], str))
+            assert(isinstance(el_zero[0], basestring))
             word_features = _get_words_from_dataset(chain([el_zero],train_set))
         except:
             raise ValueError('train_set is proabably malformed.')
@@ -136,7 +136,7 @@ class BaseClassifier(object):
             self.train_set = self._read_data(train_set, format)
         else:  # train_set is a list of tuples
             self.train_set = train_set
-        self._word_set = _get_words_from_dataset(train_set) #Keep a hidden set of unique words.
+        self._word_set = _get_words_from_dataset(self.train_set) #Keep a hidden set of unique words.
         self.train_features = None
 
     def _read_data(self, dataset, format=None):

--- a/textblob/classifiers.py
+++ b/textblob/classifiers.py
@@ -78,13 +78,20 @@ def basic_extractor(document, train_set):
     :param list train_set: Training data set, a list of tuples of the form
         ``(words, label)`` OR an iterable of strings.
     """
-    el_zero = iter(train_set).next() #Infer input from first element.
-    if isinstance(el_zero, tuple):
-        word_features = _get_words_from_dataset(train_set)
-    elif isinstance(el_zero, str):
-        word_features = train_set
+
+    try:
+        el_zero = iter(train_set).next() #Infer input from first element.
+    except StopIteration:
+        return {}
+    if isinstance(el_zero, str):
+        word_features = [w for w in chain([el_zero],train_set)]
     else:
-        raise ValueError('train_set is proabably malformed.')
+        try:
+            assert(isinstance(el_zero[0], str))
+            word_features = _get_words_from_dataset(chain([el_zero],train_set))
+        except:
+            raise ValueError('train_set is proabably malformed.')
+
     tokens = _get_document_tokens(document)
     features = dict(((u'contains({0})'.format(word), (word in tokens))
                                             for word in word_features))


### PR DESCRIPTION
Three changes:

1) basic_extractor can accept a list of strings as well as a list of
('word','label') tuples.

2) BaseClassifier now has an instance variable _word_set which is a set
of tokens seen by the classifier.

1+2) BaseClassifier.extract_features passes _word_set to extractor
rather than the training set.

3)  NLTKClassifier.update adds new words to the _word_set.
