### PR TITLE
include method to remove stopwords

### DIFF
--- a/textblob/blob.py
+++ b/textblob/blob.py
@@ -23,6 +23,7 @@ Example usage: ::
 from __future__ import unicode_literals, absolute_import
 import sys
 import json
+import re
 from collections import defaultdict
 
 import nltk
@@ -367,6 +368,16 @@ class BaseBlob(StringlikeMixin, BlobComparableMixin):
         self.stripped = lowerstrip(self.raw, all=True)
         _initialize_models(self, tokenizer, pos_tagger, np_extractor, analyzer,
                            parser, classifier)
+
+    @cached_property
+    def remove_stopwords(self,fname="stopwords.txt"):
+        """Take raw string and remove stop words.
+        :rtype: str
+        """
+        with open(fname) as f:
+            stopwords = [word for line in f for word in re.findall(r'\w+', line)]
+        clean_string = ' '.join([word for word in self.raw.split() if word not in stopwords])
+        return clean_string
 
     @cached_property
     def words(self):


### PR DESCRIPTION
included method to remove stopwords from text.

here is an example:

```
text = '''
The titular threat of The Blob has always struck me as the ultimate movie
monster: an insatiably hungry, amoeba-like mass able to penetrate
virtually any safeguard, capable of--as a doomed doctor chillingly
describes it--"assimilating flesh on contact.
Snide comparisons to gelatin be damned, it's a concept with the most
devastating of potential consequences, not unlike the grey goo scenario
proposed by technological theorists fearful of
artificial intelligence run rampant.
'''
>>> blob = TextBlob(text)
>>> blob.remove_stopwords

'\nThe titular threat of The Blob has always struck me as the ultimate movie\nmonster: an insatiably hungry, amoeba-like mass able to penetrate\nvirtually any safeguard, capable of--as a doomed doctor chillingly\ndescribes it--"assimilating flesh on contact.\nSnide comparisons to gelatin be damned, it\'s a concept with the most\ndevastating of potential consequences, not unlike the grey goo scenario\nproposed by technological theorists fearful of\nartificial intelligence run rampant.\n'
```