### PR TITLE
replace StopIteration with return

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -27,3 +27,4 @@ Contributors (chronological)
 - Tyler James Harden `@tylerjharden <https://github.com/tylerjharden>`_
 - `@pavelmalai <https://github.com/pavelmalai>`_
 - Jeff Kolb `@jeffakolb <https://github.com/jeffakolb>`_
+- Daniel Ong `@danong <https://github.com/danong>`_

--- a/textblob/_text.py
+++ b/textblob/_text.py
@@ -362,7 +362,7 @@ def _read(path, encoding="utf-8", comment=";;;"):
             if not line or (comment and line.startswith(comment)):
                 continue
             yield line
-    raise StopIteration
+    return
 
 
 class Lexicon(lazydict):


### PR DESCRIPTION
[Python 3.7](https://docs.python.org/3.7/whatsnew/3.7.html#changes-in-python-behavior) adopts [PEP 479](https://www.python.org/dev/peps/pep-0479/), which replaces `StopIteration` with `RuntimeError` when raised inside a generator. This breaks `_read`. 

 I replaced `raise StopIteration` with `return` to fix this in the most strictly-equivalent way possible but we could omit the line entirely too.

fixes #230 