### PR TITLE
Fix typo in documentation

### DIFF
--- a/textblob/tokenizers.py
+++ b/textblob/tokenizers.py
@@ -45,7 +45,7 @@ class WordTokenizer(BaseTokenizer):
 
 
 class SentenceTokenizer(BaseTokenizer):
-    """NLTK's sentence tokenizer (currently PunkSentenceTokenizer).
+    """NLTK's sentence tokenizer (currently PunktSentenceTokenizer).
     Uses an unsupervised algorithm to build a model for abbreviation words,
     collocations, and words that start sentences,
     then uses that to find sentence boundaries.


### PR DESCRIPTION
The correct name seems to be PunktSentenceTokenizer, see https://www.nltk.org/api/nltk.tokenize.html#nltk.tokenize.punkt.PunktSentenceTokenizer