### PR TITLE
Fix bug when word string type after pos_tags is not str

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -29,3 +29,4 @@ Contributors (chronological)
 - Jeff Kolb `@jeffakolb <https://github.com/jeffakolb>`_
 - Daniel Ong `@danong <https://github.com/danong>`_
 - Jamie Moschella `@jammmo <https://github.com/jammmo>`_
+- Roman Korolev `@jammmo <https://github.com/roman-y-korolev>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+0.15.3 (unreleased)
+-------------------
+
+Bug fixes:
+
+- Fix bug when ``Word`` string type after pos_tags is not a ``str``
+  (:pr:`255`). Thanks :user:`roman-y-korolev` for the patch.
+
 0.15.2 (2018-11-21)
 -------------------
 

--- a/tests/test_blob.py
+++ b/tests/test_blob.py
@@ -864,6 +864,12 @@ is managed by the non-profit Python Software Foundation.'''
         assert_raises(NameError,
             lambda: blob.classify())
 
+    def test_word_string_type_after_pos_tags_is_str(self):
+        text = 'John is a cat'
+        blob = tb.TextBlob(text)
+        for word, part_of_speech in blob.pos_tags:
+            assert type(word.string) is str
+
 
 class WordTest(TestCase):
 

--- a/tests/test_blob.py
+++ b/tests/test_blob.py
@@ -868,7 +868,7 @@ is managed by the non-profit Python Software Foundation.'''
         text = 'John is a cat'
         blob = tb.TextBlob(text)
         for word, part_of_speech in blob.pos_tags:
-            assert type(word.string) is str
+            assert type(word.string) is unicode
 
 
 class WordTest(TestCase):

--- a/textblob/blob.py
+++ b/textblob/blob.py
@@ -483,7 +483,7 @@ class BaseBlob(StringlikeMixin, BlobComparableMixin):
         if isinstance(self, TextBlob):
             return [val for sublist in [s.pos_tags for s in self.sentences] for val in sublist]
         else:
-            return [(Word(str(word), pos_tag=t), unicode(t))
+            return [(Word(unicode(word), pos_tag=t), unicode(t))
                     for word, t in self.pos_tagger.tag(self)
                     if not PUNCTUATION_REGEX.match(unicode(t))]
 

--- a/textblob/blob.py
+++ b/textblob/blob.py
@@ -483,7 +483,7 @@ class BaseBlob(StringlikeMixin, BlobComparableMixin):
         if isinstance(self, TextBlob):
             return [val for sublist in [s.pos_tags for s in self.sentences] for val in sublist]
         else:
-            return [(Word(word, pos_tag=t), unicode(t))
+            return [(Word(str(word), pos_tag=t), unicode(t))
                     for word, t in self.pos_tagger.tag(self)
                     if not PUNCTUATION_REGEX.match(unicode(t))]
 


### PR DESCRIPTION
After pos_tags word.string of all words in result have type "word", not str. If you need call str method of word.string (translate, for example) then you will call word's method.