### PR TITLE
DOC: update conda install instructions

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -22,13 +22,9 @@ This will install TextBlob and download the necessary NLTK corpora. If you need 
 With conda
 ----------
 
-.. note::
-    Conda builds are currently available for Mac OSX only.
-
 TextBlob is also available as a `conda <http://conda.pydata.org/>`_ package. To install with ``conda``, run ::
 
-
-    $ conda install -c https://conda.anaconda.org/sloria textblob
+    $ conda install -c conda-forge textblob
     $ python -m textblob.download_corpora
 
 From Source


### PR DESCRIPTION
I believe the conda install instructions are outdated.
https://textblob.readthedocs.io/en/dev/install.html#with-conda

Also fixes #244 