### PR TITLE
Fix #285 ValueError when using TweetTokenizer

### DIFF
--- a/tests/test_blob.py
+++ b/tests/test_blob.py
@@ -763,6 +763,17 @@ is managed by the non-profit Python Software Foundation.'''
         blob = tb.TextBlob("This is\ttext.", tokenizer=tokenizer)
         assert_equal(blob.tokens, tb.WordList(["This is", "text."]))
 
+    def test_can_use_a_tweet_tokenizer(self):
+        tokenizer = nltk.tokenize.TweetTokenizer()
+        blob = tb.TextBlob("This is\ttext.", tokenizer=tokenizer)
+        assert_equal(blob.tokens, tb.WordList(["This", "is", "text", "."]))
+
+    def test_can_use_a_tweet_tokenizer_with_constructor_options(self):
+        tokenizer = nltk.tokenize.TweetTokenizer(strip_handles=True, reduce_len=True)
+        blob = tb.TextBlob("@remy: This is waaaaayyyy too much for you!!!!!!", tokenizer=tokenizer)
+        assert_equal(blob.tokens, tb.WordList([':', 'This', 'is', 'waaayyy', 'too',
+            'much', 'for', 'you', '!', '!', '!']))
+
     def test_tokenize_method(self):
         tokenizer = nltk.tokenize.TabTokenizer()
         blob = tb.TextBlob("This is\ttext.")

--- a/textblob/blob.py
+++ b/textblob/blob.py
@@ -335,7 +335,8 @@ def _initialize_models(obj, tokenizer, pos_tagger,
     """Common initialization between BaseBlob and Blobber classes."""
     # tokenizer may be a textblob or an NLTK tokenizer
     obj.tokenizer = _validated_param(tokenizer, "tokenizer",
-                                    base_class=(BaseTokenizer, nltk.tokenize.api.TokenizerI),
+                                    base_class=(BaseTokenizer, nltk.tokenize.api.TokenizerI,
+                                        nltk.tokenize.casual.TweetTokenizer),
                                     default=BaseBlob.tokenizer,
                                     base_class_name="BaseTokenizer")
     obj.np_extractor = _validated_param(np_extractor, "np_extractor",


### PR DESCRIPTION
When specifying your own tokenizer, TextBlob expects a base class of `nltk.tokenize.api.TokenizerI`.  While `nltk.tokenize.TweetTokenizer` provides the required interface, it does not meet that requirement.  Added explicitly as a valid option, along with related tests.