### PR TITLE
Use chain.from_iterable in _text.py

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -30,3 +30,4 @@ Contributors (chronological)
 - Daniel Ong `@danong <https://github.com/danong>`_
 - Jamie Moschella `@jammmo <https://github.com/jammmo>`_
 - Roman Korolev `@roman-y-korolev <https://github.com/roman-y-korolev>`_
+- Ram Rachum `@cool-RR <https://github.com/cool-RR>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+0.17.0 (unreleased)
+-------------------
+
+Features:
+
+- Performance improvement: Use ``chain.from_iterable`` in ``_text.py``
+  to improve runtime and memory usage (:pr:`333`). Thanks :user:`cool-RR` for the PR.
+
 0.16.0 (2020-04-26)
 -------------------
 

--- a/textblob/_text.py
+++ b/textblob/_text.py
@@ -823,7 +823,8 @@ class Sentiment(lazydict):
             a = self.assessments(((w.lower(), None) for w in " ".join(self.tokenizer(s)).split()), negation)
         # A pattern.en.Text.
         elif hasattr(s, "sentences"):
-            a = self.assessments(((w.lemma or w.string.lower(), w.pos[:2]) for w in chain(*s)), negation)
+            a = self.assessments(((w.lemma or w.string.lower(), w.pos[:2])
+                                  for w in chain.from_iterable(s)), negation)
         # A pattern.en.Sentence or pattern.en.Chunk.
         elif hasattr(s, "lemmata"):
             a = self.assessments(((w.lemma or w.string.lower(), w.pos[:2]) for w in s.words), negation)
@@ -835,11 +836,11 @@ class Sentiment(lazydict):
         # Bag-of words is unordered: inject None between each two words
         # to stop assessments() from scanning for preceding negation & modifiers.
         elif hasattr(s, "terms"):
-            a = self.assessments(chain(*(((w, None), (None, None)) for w in s)), negation)
+            a = self.assessments(chain.from_iterable(((w, None), (None, None)) for w in s), negation)
             kwargs.setdefault("weight", lambda w: s.terms[w[0]])
         # A dict of (word, weight)-items.
         elif isinstance(s, dict):
-            a = self.assessments(chain(*(((w, None), (None, None)) for w in s)), negation)
+            a = self.assessments(chain.from_iterable(((w, None), (None, None)) for w in s), negation)
             kwargs.setdefault("weight", lambda w: s[w[0]])
         # A list of words.
         elif isinstance(s, list):


### PR DESCRIPTION
This is a faster and more idiomatic way of using `itertools.chain`. Instead of computing all the items in the iterable and storing them in memory, they are computed one-by-one and never stored as a huge list. This can save on both runtime and memory space.