### PR TITLE
Use ElementTree instead of deprecated cElementTree in Python 3

### DIFF
--- a/textblob/_text.py
+++ b/textblob/_text.py
@@ -11,9 +11,8 @@ from itertools import chain
 import types
 import os
 import re
-from xml.etree import cElementTree
 
-from .compat import text_type, basestring, imap, unicode, binary_type, PY2
+from .compat import text_type, basestring, imap, unicode, binary_type, PY2, ET
 
 try:
     MODULE = os.path.dirname(os.path.abspath(__file__))
@@ -740,7 +739,7 @@ class Sentiment(lazydict):
         if not os.path.exists(path):
             return
         words, synsets, labels = {}, {}, {}
-        xml = cElementTree.parse(path)
+        xml = ET.parse(path)
         xml = xml.getroot()
         for w in xml.findall("word"):
             if self._confidence is None \

--- a/textblob/compat.py
+++ b/textblob/compat.py
@@ -16,6 +16,7 @@ if PY2:
     imap = imap
     izip = izip
     import unicodecsv as csv
+    import xml.etree.cElementTree as ET
 
     def implements_to_string(cls):
         """Class decorator that renames __str__ to __unicode__ and
@@ -36,6 +37,7 @@ else:  # PY3
     imap = map
     izip = zip
     import csv
+    import xml.etree.ElementTree as ET
 
     implements_to_string = lambda x: x
 


### PR DESCRIPTION
Fixes #339 