### PR TITLE
Removing ctypes dependency.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -31,3 +31,4 @@ Contributors (chronological)
 - Jamie Moschella `@jammmo <https://github.com/jammmo>`_
 - Roman Korolev `@roman-y-korolev <https://github.com/roman-y-korolev>`_
 - Ram Rachum `@cool-RR <https://github.com/cool-RR>`_
+- Romain Casati `@casatir <https://github.com/casatir>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,10 @@ Features:
 - Performance improvement: Use ``chain.from_iterable`` in ``_text.py``
   to improve runtime and memory usage (:pr:`333`). Thanks :user:`cool-RR` for the PR.
 
+Other changes:
+
+- Remove usage of `ctypes` (:pr:`354`). Thanks :user:`casatir`.
+
 0.16.0 (2020-04-26)
 -------------------
 

--- a/textblob/translate.py
+++ b/textblob/translate.py
@@ -8,7 +8,6 @@ Language detection added by Steven Loria.
 from __future__ import absolute_import
 
 import codecs
-import ctypes
 import json
 import re
 
@@ -106,6 +105,14 @@ def _calculate_tk(source):
     # Source: https://github.com/soimort/translate-shell/issues/94#issuecomment-165433715
     # Source: http://www.liuxiatool.com/t.php
 
+    def c_int(x, nbits=32):
+        """ C cast to int32, int16, int8... """
+        return (x & ((1 << (nbits - 1)) - 1)) - (x & (1 << (nbits - 1)))
+
+    def c_uint(x, nbits=32):
+        """ C cast to uint32, uint16, uint8... """
+        return x & ((1 << nbits) - 1)
+
     tkk = [406398, 561666268 + 1526272306]
     b = tkk[0]
 
@@ -118,10 +125,10 @@ def _calculate_tk(source):
         for c in range(0, len(b) - 2, 3):
             d = b[c + 2]
             d = ord(d) - 87 if d >= 'a' else int(d)
-            xa = ctypes.c_uint32(a).value
+            xa = c_uint(a)
             d = xa >> d if b[c + 1] == '+' else xa << d
             a = a + d & 4294967295 if b[c] == '+' else a ^ d
-        return ctypes.c_int32(a).value
+        return c_int(a)
 
     a = b
 


### PR DESCRIPTION
Importing `TextBlob` in [Pyodide](https://github.com/iodide-project/pyodide) fails because `ctypes` is not supported there.

For now, I am stuck with old version `0.11.0`, the last without `ctypes` dependency.

Looking at the code, it seems pretty easy to get rid of this dependency, doing `unit32` and `int32` casting in pure Python. See the PR.

Python 3 tests are OK but I can't test with Python 2.7 since `nltk`no longer supports it.