### PR TITLE
docs: fix simple typo, incompatiblity -> incompatibility

### DIFF
--- a/textblob/taggers.py
+++ b/textblob/taggers.py
@@ -1,4 +1,4 @@
-'''Default taggers to the English taggers for backwards incompatiblity, so you
+'''Default taggers to the English taggers for backwards incompatibility, so you
 can still do
 
 >>> from textblob.taggers import NLTKTagger


### PR DESCRIPTION
There is a small typo in textblob/taggers.py.

Should read `incompatibility` rather than `incompatiblity`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md