### PR TITLE
fea: added proxy solution for urllib requests.

### DIFF
--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+import time
+import json
+import unittest
+import urllib.request
+from nose.tools import *  # PEP8 asserts
+
+from textblob.proxy import set_proxy
+
+
+class TestProxy(unittest.TestCase):
+    def test_proxy(self):
+        proxy_service_url = "http://localhost:8118"
+        ip_get_url = "http://ip-api.com/json/"
+        set_proxy(proxy_service_url)
+        collected_ip_addresses = []
+        for x in range(5):
+            with urllib.request.urlopen(ip_get_url) as url:
+                json_data = json.loads(url.read().decode("utf-8"))
+                print("IP address:", json_data["query"])
+                ip_changed = (
+                    True if json_data["query"] not in collected_ip_addresses else False
+                )
+                self.assertTrue(ip_changed, "IP not changed.")
+                collected_ip_addresses.append(json_data["query"])
+                time.sleep(2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/textblob/proxy.py
+++ b/textblob/proxy.py
@@ -1,0 +1,25 @@
+#-*- coding: utf-8 -*-
+"""
+Natural Language Toolkit: Utility functions
+
+Copyright (C) 2001-2021 NLTK Project
+Author: Steven Bird <stevenbird1@gmail.com>
+URL: <http://nltk.org/>
+For license information, see LICENSE.TXT"""
+import nltk
+
+
+def set_proxy(proxy, user=None, password=""):
+    """
+    Set the HTTP proxy for Python to download through.
+
+    If ``proxy`` is None then tries to set proxy from environment or system
+    settings.
+
+    :param proxy: The HTTP proxy server to use. For example:
+        'http://proxy.example.com:3128/'
+    :param user: The username to authenticate with. Use None to disable
+        authentication.
+    :param password: The password to authenticate with.
+    """
+    nltk.set_proxy(proxy, user=user, password=password)


### PR DESCRIPTION
Added proxy solution for urllib requests. Reusing nltk.set_proxy() solution.

This idea created by this issue: 
https://stackoverflow.com/questions/34036158/setting-proxy-for-textblob#37610845. 

I saw that TextBlob library is using NLTK in some modules. 
Please double check license of usage of this solution. I have copied original author "license" text.:
![image](https://user-images.githubusercontent.com/37572303/130320753-44e30ca6-3dbe-453d-ab11-776ae2c55969.png)

New module:
textblob -> proxy.py

Test file:
tests -> test_proxy.py