### PR TITLE
probably better test

### DIFF
--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -119,7 +119,10 @@ class TestRegistry(unittest.TestCase):
 
         assert_true(CustomFormat in registry.values())
         assert_true('trt' in registry.keys())
+        del formats.get_registry()['trt']
 
 
 if __name__ == '__main__':
     unittest.main()
+
+


### PR DESCRIPTION
When I run pytest --flake-finder, this test gave me an error about the first assertion because in the last run this is already in the dictionary, so I think it might be better to delete the key at the end of the test so if people who want to find flaky test run this tool again in the future they won't get the error. That's the reason I open this PR.