### PR TITLE
fix SyntaxWarning problem new in 3.12

### DIFF
--- a/textblob/_text.py
+++ b/textblob/_text.py
@@ -215,8 +215,8 @@ ABBREVIATIONS = abbreviations = set((
     "pred.", "pres.", "p.m.", "ref.", "v.", "vs.", "w/"
 ))
 
-RE_ABBR1 = re.compile("^[A-Za-z]\.$")       # single letter, "T. De Smedt"
-RE_ABBR2 = re.compile("^([A-Za-z]\.)+$")    # alternating letters, "U.S."
+RE_ABBR1 = re.compile("^[A-Za-z][.]$")      # single letter, "T. De Smedt"
+RE_ABBR2 = re.compile("^([A-Za-z][.])+$")   # alternating letters, "U.S."
 RE_ABBR3 = re.compile("^[A-Z][" + "|".join( # capital followed by consonants, "Mr."
         "bcdfghjklmnpqrstvwxz") + "]+.$")
 


### PR DESCRIPTION
I've been messing with the nogil version of 3.12 alpha. It begins raising SyntaxWarning for at least some strings where a backslash would be meaningless. `textblob._text` has a couple regular expressions containing `\.` which aren't in raw strings. This PR solves that problem in one way, by replacing `\.` with `[.]`. An alternative way to do this would be to convert to raw strings. I find `[...]` more readable than using a backslash. YMMV.
