### PR TITLE
Bump up NLTK minimum version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 ]
 keywords = ["textblob", "nlp", 'linguistics', 'nltk', 'pattern']
 requires-python = ">=3.8"
-dependencies = ["nltk>=3.8"]
+dependencies = ["nltk>=3.9"]
 
 [project.urls]
 Changelog = "https://textblob.readthedocs.io/en/latest/changelog.html"

--- a/src/textblob/download_corpora.py
+++ b/src/textblob/download_corpora.py
@@ -18,7 +18,7 @@ import nltk
 
 MIN_CORPORA = [
     "brown",  # Required for FastNPExtractor
-    "punkt",  # Required for WordTokenizer
+    "punkt_tab",  # Required for WordTokenizer
     "wordnet",  # Required for lemmatization
     "averaged_perceptron_tagger",  # Required for NLTKTagger
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ envlist =
 [testenv]
 extras = tests
 deps =
-    lowest: nltk==3.8
+    lowest: nltk==3.9
 commands = pytest {posargs}
 
     


### PR DESCRIPTION
Bump the NLTK minimum version to 3.9, since 3.8 is vulnerable to CVE-2024-39705. 

In order to bump up to 3.9 we need to download `punkt_tab` instead of `punkt`, see the github issue https://github.com/nltk/nltk/issues/3266 for more info.