### PR TITLE
fix: update corpora module names

### DIFF
--- a/src/textblob/download_corpora.py
+++ b/src/textblob/download_corpora.py
@@ -18,9 +18,9 @@ import nltk
 
 MIN_CORPORA = [
     "brown",  # Required for FastNPExtractor
-    "punkt",  # Required for WordTokenizer
+    "punkt_tab",  # Required for WordTokenizer
     "wordnet",  # Required for lemmatization
-    "averaged_perceptron_tagger",  # Required for NLTKTagger
+    "averaged_perceptron_tagger_eng",  # Required for NLTKTagger
 ]
 
 ADDITIONAL_CORPORA = [


### PR DESCRIPTION
Updates corpora module names to fix a missing corpora error when running:

python -m textblob.download_corpora

This should fix CI errors and #482 and #474 but may break NLTK v3.8 support