### PR TITLE
chore: update Python versions and CI

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -15,6 +15,7 @@ jobs:
         include:
           - { name: "3.9", python: "3.9", tox: py39 }
           - { name: "3.13", python: "3.13", tox: py313 }
+          - { name: "lowest", python: "3.9", tox: py39-lowest }
     steps:
       - uses: actions/checkout@v4.0.0
       - uses: actions/setup-python@v5

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -21,7 +21,9 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
       - name: Download nltk data
-        run: python -m textblob.download_corpora
+        run: |
+          pip install .
+          python -m textblob.download_corpora
       - run: python -m pip install tox
       - run: python -m tox -e${{ matrix.tox }}
   build:

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -13,18 +13,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: "3.8", python: "3.8", tox: py38 }
-          - { name: "3.12", python: "3.12", tox: py312 }
-          - { name: "lowest", python: "3.8", tox: py38-lowest }
+          - { name: "3.9", python: "3.9", tox: py39 }
+          - { name: "3.13", python: "3.13", tox: py313 }
     steps:
       - uses: actions/checkout@v4.0.0
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
       - name: Download nltk data
-        run: wget https://s3.amazonaws.com/textblob/nltk_data-0.11.0.tar.gz
-      - name: Extract nltk data
-        run: tar -xzvf nltk_data-0.11.0.tar.gz -C ~
+        run: python -m textblob.download_corpora
       - run: python -m pip install tox
       - run: python -m tox -e${{ matrix.tox }}
   build:

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -34,3 +34,4 @@ Contributors (chronological)
 - Romain Casati `@casatir <https://github.com/casatir>`_
 - Evgeny Kemerov `@sudoguy <https://github.com/sudoguy>`_
 - Karthikeyan Singaravelan `@tirkarthi <https://github.com/tirkarthi>`_
+- John Franey `@johnfraney <https://github.com/johnfraney>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,11 @@ Changelog
 0.19.0 (unreleased)
 ___________________
 
+Bug fixes:
+
+- Fix ``textblob.download_corpora`` script (:issue:`474`).
+  Thanks :user:`cagan-elden` for reporting.
+
 Changes:
 
 - Remove vendorized ``unicodecsv`` module, as it's no longer used.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,9 +4,11 @@ Changelog
 0.19.0 (unreleased)
 ___________________
 
-Other changes:
+Changes:
 
 - Remove vendorized ``unicodecsv`` module, as it's no longer used.
+- Support Python 3.9-3.13 and nltk>=3.9 (:pr:`486`)
+  Thanks :user:`johnfraney` for the PR.
 
 0.18.0 (2024-02-15)
 -------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,16 +9,16 @@ classifiers = [
   "Intended Audience :: Developers",
   "License :: OSI Approved :: MIT License",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Topic :: Text Processing :: Linguistic",
 ]
 keywords = ["textblob", "nlp", 'linguistics', 'nltk', 'pattern']
-requires-python = ">=3.8"
-dependencies = ["nltk>=3.8"]
+requires-python = ">=3.9"
+dependencies = ["nltk>=3.9"]
 
 [project.urls]
 Changelog = "https://textblob.readthedocs.io/en/latest/changelog.html"

--- a/src/textblob/download_corpora.py
+++ b/src/textblob/download_corpora.py
@@ -18,9 +18,9 @@ import nltk
 
 MIN_CORPORA = [
     "brown",  # Required for FastNPExtractor
-    "punkt",  # Required for WordTokenizer
+    "punkt_tab",  # Required for WordTokenizer
     "wordnet",  # Required for lemmatization
-    "averaged_perceptron_tagger",  # Required for NLTKTagger
+    "averaged_perceptron_tagger_eng",  # Required for NLTKTagger
 ]
 
 ADDITIONAL_CORPORA = [

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,12 @@
 envlist =
     lint
     py{39,310,311,312,313}
+    py39-lowest
 
 [testenv]
 extras = tests
+deps =
+    lowest: nltk==3.9
 commands = pytest {posargs}
 
     

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,10 @@
 [tox]
 envlist =
     lint
-    py{38,39,310,311,312}
-    py38-lowest
+    py{39,310,311,312,313}
 
 [testenv]
 extras = tests
-deps =
-    lowest: nltk==3.8
 commands = pytest {posargs}
 
     


### PR DESCRIPTION
Updates supported Python versions to be 3.9-3.13 and updates CI to use the built-in `textblob.download_corpora` command. Also updates corpora module names to fix a missing corpora error when running:

python -m textblob.download_corpora

## Notes

This should fix CI errors and https://github.com/sloria/TextBlob/issues/482 and https://github.com/sloria/TextBlob/issues/474 but removes NLTK v3.8 support

This requires updating the repo's required status checks to be Python 3.9 and 3.13