### PR TITLE
Add feature for detecting the precentage of alphabet characters in a text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ README.html
 
 # ruff
 .ruff_cache
+
+# idea
+.idea

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -35,3 +35,4 @@ Contributors (chronological)
 - Evgeny Kemerov `@sudoguy <https://github.com/sudoguy>`_
 - Karthikeyan Singaravelan `@tirkarthi <https://github.com/tirkarthi>`_
 - John Franey `@johnfraney <https://github.com/johnfraney>`_
+- `@mikebgrep <https://github.com/mikebgrep>`_

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -300,7 +300,7 @@ Use ``blob.alphabets`` to get the precentage of the alphabets containing in `str
 
 .. doctest::
 
-    >>> blob = TextBlob("hello Привет  שלום 안녕하세요")
+    >>> blob = TextBlob("hello Привет  שלום 안녕하")
     >>> blob.alphabets
     [('LATIN', 27.78), ('CYRILLIC', 33.33), ('HEBREW', 22.22), ('HANGUL', 16.67)]
     >>> blob.alphabets[0]

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -293,6 +293,22 @@ Use ``sentence.start`` and ``sentence.end`` to get the indices where a sentence 
     Simple is better than complex.
     ---- Starts at index 65, Ends at index 95
 
+Detect Alphabets Percantages
+--------------------------------------
+
+Use ``blob.alphabets`` to get the precentage of the alphabets containing in `string`.
+
+.. doctest::
+
+    >>> blob = TextBlob("hello Привет  שלום 안녕하세요")
+    >>> blob.alphabets
+    [('LATIN', 27.78), ('CYRILLIC', 33.33), ('HEBREW', 22.22), ('HANGUL', 16.67)]
+    >>> blob.alphabets[0]
+    ('LATIN', 27.78)
+    >>> blob.alphabets[0][1]
+    27.78
+
+
 Next Steps
 ++++++++++
 

--- a/src/textblob/alphabets_detection.py
+++ b/src/textblob/alphabets_detection.py
@@ -116,33 +116,19 @@ def detect_alphabets(text: str):
     """
     only_chars = [x for x in text if x.isalpha()]
     final_result = []
-    current_percentage = 0
+    progress = 0
 
     for alphabet_key, alphabet_value in alphabets.items():
         chars = sum(1 for x in only_chars if x in alphabet_value)
 
         percentage = chars / len(only_chars) * 100
-        is_completed, current_percentage = is_percentage_completed(
-            percentage,
-            current_percentage,
-        )
+        progress += percentage
 
         if percentage > 0:
             final_result.append((alphabet_key.name, round(percentage, 2)))
 
-        if is_completed:
+        if progress >= 99.99:
             return final_result
 
     final_result.append((Alphabet.STRING_CONTAINS_NOT_IMPLEMENTED_ALPHABET.name, 0))
     return final_result
-
-
-def is_percentage_completed(
-    percentage: int | float,
-    current_percent: int,
-) -> tuple[bool, float]:
-    """Function to check if the percentage is >= 99.99"""
-    progress = current_percent + percentage
-    if progress >= 99.99:
-        return True, progress
-    return False, progress

--- a/src/textblob/alphabets_detection.py
+++ b/src/textblob/alphabets_detection.py
@@ -1,7 +1,6 @@
 from enum import Enum
 from string import punctuation, whitespace
 from typing import List, Tuple
-from unicodedata import category
 
 from textblob.utils import unicode_range
 
@@ -22,9 +21,24 @@ tifinagh = unicode_range(0x2D30, 0x2D7F)
 osmanya = unicode_range(0x10480, 0x104AF)
 mongolian = unicode_range(0x1800, 0x18AF)
 ol_chiki = unicode_range(0x1C50, 0x1C7F)
+armenian = unicode_range(0x0530, 0x058F)
+devanagari = unicode_range(0x0900, 0x097F)
+bengali = unicode_range(0x0980, 0x09FF)
+gurmukhi = unicode_range(0x0A00, 0x0A7F)
+tamil = unicode_range(0x0B80, 0x0BFF)
+telugu = unicode_range(0x0C00, 0x0C7F)
+gujarati = unicode_range(0x0A80, 0x0AFF)
+kannada = unicode_range(0x0C80, 0x0CFF)
+malayalam = unicode_range(0x0D00, 0x0D7F)
+sinhala = unicode_range(0x0D80, 0x0DFF)
+thai = unicode_range(0x0E00, 0x0E7F)
+lao = unicode_range(0x0E80, 0x0EFF)
+myanmar = unicode_range(0x1000, 0x109F)
+khmer = unicode_range(0x1780, 0x17FF)
 
 
 class Alphabet(Enum):
+    STRING_CONTAINS_NOT_IMPLEMENTED_ALPHABET = 0
     LATIN = 1
     CYRILLIC = 2
     ARABIC = 3
@@ -38,6 +52,20 @@ class Alphabet(Enum):
     OSMANYA = 11
     MONGOLIAN = 12
     OL_CHIKI = 13
+    ARMENIAN = 14
+    DEVANAGARI = 15
+    BENGALI = 16
+    GURMUKHI = 17
+    TAMIL = 18
+    TELUGU = 19
+    GUJARATI = 20
+    KANNADA = 21
+    MALAYALAM = 22
+    SINHALA = 23
+    THAI = 24
+    LAO = 25
+    MYANMAR = 26
+    KHMER = 27
 
 
 alphabets = {
@@ -53,29 +81,28 @@ alphabets = {
     Alphabet.TIFINAGH: tifinagh,
     Alphabet.OSMANYA: osmanya,
     Alphabet.MONGOLIAN: mongolian,
-    Alphabet.OL_CHIKI: ol_chiki
+    Alphabet.OL_CHIKI: ol_chiki,
+    Alphabet.ARMENIAN: armenian,
+    Alphabet.DEVANAGARI: devanagari,
+    Alphabet.BENGALI: bengali,
+    Alphabet.GURMUKHI: gurmukhi,
+    Alphabet.TAMIL: tamil,
+    Alphabet.TELUGU: telugu,
+    Alphabet.GUJARATI: gujarati,
+    Alphabet.KANNADA: kannada,
+    Alphabet.MALAYALAM: malayalam,
+    Alphabet.SINHALA: sinhala,
+    Alphabet.THAI: thai,
+    Alphabet.LAO: lao,
+    Alphabet.MYANMAR: myanmar,
+    Alphabet.KHMER: khmer,
 }
 
-test_string = (
-        "Latin: hello; " +
-        "Cyrillic: Привет; " +
-        "Arabic: مرحبا; " +
-        "Hebrew: שלום; " +
-        "Hangul: 안녕하세요; " +
-        "Georgian: გამარჯობა; " +
-        "Ethiopic: ሰላም; " +
-        "Thaana: ޝީހް; " +
-        "N’Ko: ߣߊ߫; " +
-        "Tifinagh: ⴰⵣⵓⵍ; " +
-        "Osmanya: 𐒝𐒛𐒒𐒚; " +
-        "Mongolian: ᠰᠠᠶᠠᠨ ᠤᠯᠤ; " +
-        "Ol Chiki: ᱦᱚᱞᱚ"
-)
 
-
-def alphabets_detection(text: str):
+def detect_alphabets(text: str):
     only_chars = [x for x in text if x.isalpha()]
     alphabets_result = {}
+    final_result = []
     current_percentage = 0
 
     for alphabet_key, alphabet_value in alphabets.items():
@@ -83,18 +110,24 @@ def alphabets_detection(text: str):
         is_completed, result, current_percentage = is_current_percentage_completed(chars, current_percentage,
                                                                                    only_chars, alphabet_key,
                                                                                    alphabets_result)
-        if is_completed:
-            return result
 
-    return None
+        final_result.append((alphabet_key.name, result[alphabet_key.name]))
+
+        if is_completed:
+            return final_result
+
+    final_result.append((Alphabet.STRING_CONTAINS_NOT_IMPLEMENTED_ALPHABET.name, 0))
+
+    return final_result
 
 
 def is_current_percentage_completed(alphabet_chars_sum: int, current_percent: int, chars: List,
-                                    current_language: Alphabet, languages_result: dict) -> Tuple[bool, dict, float]:
+                                    current_alphabet: Alphabet, alphabets_result: dict) -> Tuple[bool, dict, float]:
     percentage = alphabet_chars_sum / len(chars) * 100
-    languages_result[current_language.name] = percentage
 
-    if current_percent + percentage >= 100:
-        return True, languages_result, current_percent + percentage
+    if percentage > 0:
+        alphabets_result[current_alphabet.name] = round(percentage, 2)
 
-    return False, languages_result, current_percent + percentage
+    if current_percent + percentage >= 99.99:
+        return True, alphabets_result, current_percent + percentage
+    return False, alphabets_result, current_percent + percentage

--- a/src/textblob/alphabets_detection.py
+++ b/src/textblob/alphabets_detection.py
@@ -99,10 +99,10 @@ alphabets = {
 
 
 def detect_alphabets(text: str):
-    """Detects the percentage of character containing in a string `text` and return list with tuples.
-    Tuple contains (Alphabet.name, % of the alphabet in the `text`)
-    Any additional languages should be added at top of the file as unicode ranges and
-    appended to  the `alphabets` map and `Alphabet` enum.
+    """Detects the percentage of character containing in a string `text` and
+    return list with tuples. Tuple contains (Alphabet.name, % of the alphabet
+    in the `text`). Any additional languages should be added at top of the file
+    as unicode ranges and appended to  the `alphabets` map and `Alphabet` enum.
     """
     only_chars = [x for x in text if x.isalpha()]
     alphabets_result = {}

--- a/src/textblob/alphabets_detection.py
+++ b/src/textblob/alphabets_detection.py
@@ -115,7 +115,6 @@ def detect_alphabets(text: str):
     as unicode ranges and appended to  the `alphabets` map and `Alphabet` enum.
     """
     only_chars = [x for x in text if x.isalpha()]
-    alphabets_result = {}
     final_result = []
     current_percentage = 0
 
@@ -123,12 +122,14 @@ def detect_alphabets(text: str):
         chars = sum(1 for x in only_chars if x in alphabet_value)
 
         percentage = chars / len(only_chars) * 100
-        is_completed, result, current_percentage = is_percentage_completed(
-            percentage, current_percentage, alphabet_key, alphabets_result
+        is_completed, current_percentage = is_percentage_completed(
+            percentage,
+            current_percentage,
         )
 
         if percentage > 0:
-            final_result.append((alphabet_key.name, result[alphabet_key.name]))
+            final_result.append((alphabet_key.name, round(percentage, 2)))
+
         if is_completed:
             return final_result
 
@@ -139,13 +140,9 @@ def detect_alphabets(text: str):
 def is_percentage_completed(
     percentage: int | float,
     current_percent: int,
-    current_alphabet: Alphabet,
-    alphabets_result: dict,
-) -> tuple[bool, dict, float]:
+) -> tuple[bool, float]:
     """Function to check if the percentage is >= 99.99"""
-    if percentage > 0:
-        alphabets_result[current_alphabet.name] = round(percentage, 2)
-
-    if current_percent + percentage >= 99.99:
-        return True, alphabets_result, current_percent + percentage
-    return False, alphabets_result, current_percent + percentage
+    progress = current_percent + percentage
+    if progress >= 99.99:
+        return True, progress
+    return False, progress

--- a/src/textblob/alphabets_detection.py
+++ b/src/textblob/alphabets_detection.py
@@ -130,5 +130,5 @@ def detect_alphabets(text: str):
         if progress >= 99.99:
             return result
 
-    final_result.append((Alphabet.STRING_CONTAINS_NOT_IMPLEMENTED_ALPHABET.name, 0))
+    result.append((Alphabet.STRING_CONTAINS_NOT_IMPLEMENTED_ALPHABET.name, 0))
     return result

--- a/src/textblob/alphabets_detection.py
+++ b/src/textblob/alphabets_detection.py
@@ -115,7 +115,7 @@ def detect_alphabets(text: str):
     as unicode ranges and appended to  the `alphabets` map and `Alphabet` enum.
     """
     only_chars = [x for x in text if x.isalpha()]
-    final_result = []
+    result = []
     progress = 0
 
     for alphabet_key, alphabet_value in alphabets.items():
@@ -125,10 +125,10 @@ def detect_alphabets(text: str):
         progress += percentage
 
         if percentage > 0:
-            final_result.append((alphabet_key.name, round(percentage, 2)))
+            result.append((alphabet_key.name, round(percentage, 2)))
 
         if progress >= 99.99:
             return final_result
 
     final_result.append((Alphabet.STRING_CONTAINS_NOT_IMPLEMENTED_ALPHABET.name, 0))
-    return final_result
+    return result

--- a/src/textblob/alphabets_detection.py
+++ b/src/textblob/alphabets_detection.py
@@ -1,15 +1,25 @@
 from enum import Enum
-from typing import Tuple
 
 from textblob.utils import unicode_range
 
-latin = unicode_range(0x0041, 0x005A) + unicode_range(0x0061, 0x007A) + unicode_range(0x00C0, 0x00FF) + unicode_range(
-    0x0100, 0x017F)
-cyrillic = unicode_range(0x0400, 0x04FF) + unicode_range(0x0500, 0x052F) + unicode_range(0x2DE0,
-                                                                                         0x2DFF) + unicode_range(0xA640,
-                                                                                                                 0xA69F)
-arabic = unicode_range(0x0600, 0x06FF) + unicode_range(0x0750, 0x077F) + unicode_range(0xFB50, 0xFDFF) + unicode_range(
-    0xFE70, 0xFEFF)
+latin = (
+    unicode_range(0x0041, 0x005A)
+    + unicode_range(0x0061, 0x007A)
+    + unicode_range(0x00C0, 0x00FF)
+    + unicode_range(0x0100, 0x017F)
+)
+cyrillic = (
+    unicode_range(0x0400, 0x04FF)
+    + unicode_range(0x0500, 0x052F)
+    + unicode_range(0x2DE0, 0x2DFF)
+    + unicode_range(0xA640, 0xA69F)
+)
+arabic = (
+    unicode_range(0x0600, 0x06FF)
+    + unicode_range(0x0750, 0x077F)
+    + unicode_range(0xFB50, 0xFDFF)
+    + unicode_range(0xFE70, 0xFEFF)
+)
 hebrew = unicode_range(0x0590, 0x05FF)
 hangul = unicode_range(0xAC00, 0xD7AF) + unicode_range(0x1100, 0x11FF)
 georgian = unicode_range(0x10A0, 0x10FF)
@@ -113,7 +123,9 @@ def detect_alphabets(text: str):
         chars = sum(1 for x in only_chars if x in alphabet_value)
 
         percentage = chars / len(only_chars) * 100
-        is_completed, result, current_percentage = is_percentage_completed(percentage, current_percentage, alphabet_key, alphabets_result)
+        is_completed, result, current_percentage = is_percentage_completed(
+            percentage, current_percentage, alphabet_key, alphabets_result
+        )
 
         if percentage > 0:
             final_result.append((alphabet_key.name, result[alphabet_key.name]))
@@ -124,7 +136,12 @@ def detect_alphabets(text: str):
     return final_result
 
 
-def is_percentage_completed(percentage: int | float, current_percent: int, current_alphabet: Alphabet, alphabets_result: dict) -> Tuple[bool, dict, float]:
+def is_percentage_completed(
+    percentage: int | float,
+    current_percent: int,
+    current_alphabet: Alphabet,
+    alphabets_result: dict,
+) -> tuple[bool, dict, float]:
     """Function to check if the percentage is >= 99.99"""
     if percentage > 0:
         alphabets_result[current_alphabet.name] = round(percentage, 2)

--- a/src/textblob/alphabets_detection.py
+++ b/src/textblob/alphabets_detection.py
@@ -130,5 +130,5 @@ def detect_alphabets(text: str):
         if progress >= 99.99:
             return result
 
-    result.append((Alphabet.STRING_CONTAINS_NOT_IMPLEMENTED_ALPHABET.name, 0))
+    result.append((Alphabet.STRING_CONTAINS_NOT_IMPLEMENTED_ALPHABET.name, round(100 - progress, 2))
     return result

--- a/src/textblob/alphabets_detection.py
+++ b/src/textblob/alphabets_detection.py
@@ -1,0 +1,100 @@
+from enum import Enum
+from string import punctuation, whitespace
+from typing import List, Tuple
+from unicodedata import category
+
+from textblob.utils import unicode_range
+
+latin = unicode_range(0x0041, 0x005A) + unicode_range(0x0061, 0x007A) + unicode_range(0x00C0, 0x00FF) + unicode_range(
+    0x0100, 0x017F)
+cyrillic = unicode_range(0x0400, 0x04FF) + unicode_range(0x0500, 0x052F) + unicode_range(0x2DE0,
+                                                                                         0x2DFF) + unicode_range(0xA640,
+                                                                                                                 0xA69F)
+arabic = unicode_range(0x0600, 0x06FF) + unicode_range(0x0750, 0x077F) + unicode_range(0xFB50, 0xFDFF) + unicode_range(
+    0xFE70, 0xFEFF)
+hebrew = unicode_range(0x0590, 0x05FF)
+hangul = unicode_range(0xAC00, 0xD7AF) + unicode_range(0x1100, 0x11FF)
+georgian = unicode_range(0x10A0, 0x10FF)
+ethiopic = unicode_range(0x1200, 0x137F)
+thaana = unicode_range(0x0780, 0x07BF)
+nko = unicode_range(0x07C0, 0x07FF)
+tifinagh = unicode_range(0x2D30, 0x2D7F)
+osmanya = unicode_range(0x10480, 0x104AF)
+mongolian = unicode_range(0x1800, 0x18AF)
+ol_chiki = unicode_range(0x1C50, 0x1C7F)
+
+
+class Alphabet(Enum):
+    LATIN = 1
+    CYRILLIC = 2
+    ARABIC = 3
+    HEBREW = 4
+    HANGUL = 5
+    GEORGIAN = 6
+    ETHIOPIC = 7
+    THAANA = 8
+    NKO = 9
+    TIFINAGH = 10
+    OSMANYA = 11
+    MONGOLIAN = 12
+    OL_CHIKI = 13
+
+
+alphabets = {
+    Alphabet.LATIN: latin,
+    Alphabet.CYRILLIC: cyrillic,
+    Alphabet.ARABIC: arabic,
+    Alphabet.HEBREW: hebrew,
+    Alphabet.HANGUL: hangul,
+    Alphabet.GEORGIAN: georgian,
+    Alphabet.ETHIOPIC: ethiopic,
+    Alphabet.THAANA: thaana,
+    Alphabet.NKO: nko,
+    Alphabet.TIFINAGH: tifinagh,
+    Alphabet.OSMANYA: osmanya,
+    Alphabet.MONGOLIAN: mongolian,
+    Alphabet.OL_CHIKI: ol_chiki
+}
+
+test_string = (
+        "Latin: hello; " +
+        "Cyrillic: Привет; " +
+        "Arabic: مرحبا; " +
+        "Hebrew: שלום; " +
+        "Hangul: 안녕하세요; " +
+        "Georgian: გამარჯობა; " +
+        "Ethiopic: ሰላም; " +
+        "Thaana: ޝީހް; " +
+        "N’Ko: ߣߊ߫; " +
+        "Tifinagh: ⴰⵣⵓⵍ; " +
+        "Osmanya: 𐒝𐒛𐒒𐒚; " +
+        "Mongolian: ᠰᠠᠶᠠᠨ ᠤᠯᠤ; " +
+        "Ol Chiki: ᱦᱚᱞᱚ"
+)
+
+
+def alphabets_detection(text: str):
+    only_chars = [x for x in text if x.isalpha()]
+    alphabets_result = {}
+    current_percentage = 0
+
+    for alphabet_key, alphabet_value in alphabets.items():
+        chars = sum(1 for x in only_chars if x in alphabet_value)
+        is_completed, result, current_percentage = is_current_percentage_completed(chars, current_percentage,
+                                                                                   only_chars, alphabet_key,
+                                                                                   alphabets_result)
+        if is_completed:
+            return result
+
+    return None
+
+
+def is_current_percentage_completed(alphabet_chars_sum: int, current_percent: int, chars: List,
+                                    current_language: Alphabet, languages_result: dict) -> Tuple[bool, dict, float]:
+    percentage = alphabet_chars_sum / len(chars) * 100
+    languages_result[current_language.name] = percentage
+
+    if current_percent + percentage >= 100:
+        return True, languages_result, current_percent + percentage
+
+    return False, languages_result, current_percent + percentage

--- a/src/textblob/alphabets_detection.py
+++ b/src/textblob/alphabets_detection.py
@@ -119,16 +119,16 @@ def detect_alphabets(text: str):
     progress = 0
 
     for alphabet_key, alphabet_value in alphabets.items():
-        chars = sum(1 for x in only_chars if x in alphabet_value)
+        found_chars_sum = sum(1 for x in only_chars if x in alphabet_value)
 
-        percentage = chars / len(only_chars) * 100
+        percentage = found_chars_sum / len(only_chars) * 100
         progress += percentage
 
         if percentage > 0:
             result.append((alphabet_key.name, round(percentage, 2)))
 
         if progress >= 99.99:
-            return final_result
+            return result
 
     final_result.append((Alphabet.STRING_CONTAINS_NOT_IMPLEMENTED_ALPHABET.name, 0))
     return result

--- a/src/textblob/alphabets_detection.py
+++ b/src/textblob/alphabets_detection.py
@@ -1,6 +1,5 @@
 from enum import Enum
-from string import punctuation, whitespace
-from typing import List, Tuple
+from typing import Tuple
 
 from textblob.utils import unicode_range
 
@@ -100,6 +99,11 @@ alphabets = {
 
 
 def detect_alphabets(text: str):
+    """Detects the percentage of character containing in a string `text` and return list with tuples.
+    Tuple contains (Alphabet.name, % of the alphabet in the `text`)
+    Any additional languages should be added at top of the file as unicode ranges and
+    appended to  the `alphabets` map and `Alphabet` enum.
+    """
     only_chars = [x for x in text if x.isalpha()]
     alphabets_result = {}
     final_result = []
@@ -107,24 +111,21 @@ def detect_alphabets(text: str):
 
     for alphabet_key, alphabet_value in alphabets.items():
         chars = sum(1 for x in only_chars if x in alphabet_value)
-        is_completed, result, current_percentage = is_current_percentage_completed(chars, current_percentage,
-                                                                                   only_chars, alphabet_key,
-                                                                                   alphabets_result)
 
-        final_result.append((alphabet_key.name, result[alphabet_key.name]))
+        percentage = chars / len(only_chars) * 100
+        is_completed, result, current_percentage = is_percentage_completed(percentage, current_percentage, alphabet_key, alphabets_result)
 
+        if percentage > 0:
+            final_result.append((alphabet_key.name, result[alphabet_key.name]))
         if is_completed:
             return final_result
 
     final_result.append((Alphabet.STRING_CONTAINS_NOT_IMPLEMENTED_ALPHABET.name, 0))
-
     return final_result
 
 
-def is_current_percentage_completed(alphabet_chars_sum: int, current_percent: int, chars: List,
-                                    current_alphabet: Alphabet, alphabets_result: dict) -> Tuple[bool, dict, float]:
-    percentage = alphabet_chars_sum / len(chars) * 100
-
+def is_percentage_completed(percentage: int | float, current_percent: int, current_alphabet: Alphabet, alphabets_result: dict) -> Tuple[bool, dict, float]:
+    """Function to check if the percentage is >= 99.99"""
     if percentage > 0:
         alphabets_result[current_alphabet.name] = round(percentage, 2)
 

--- a/src/textblob/alphabets_detection.py
+++ b/src/textblob/alphabets_detection.py
@@ -119,9 +119,9 @@ def detect_alphabets(text: str):
     progress = 0
 
     for alphabet_key, alphabet_value in alphabets.items():
-        found_chars_sum = sum(1 for x in only_chars if x in alphabet_value)
+        found_chars_count = sum(1 for x in only_chars if x in alphabet_value)
 
-        percentage = found_chars_sum / len(only_chars) * 100
+        percentage = found_chars_count / len(only_chars) * 100
         progress += percentage
 
         if percentage > 0:

--- a/src/textblob/alphabets_detection.py
+++ b/src/textblob/alphabets_detection.py
@@ -47,7 +47,7 @@ khmer = unicode_range(0x1780, 0x17FF)
 
 
 class Alphabet(Enum):
-    STRING_CONTAINS_NOT_IMPLEMENTED_ALPHABET = 0
+    NOT_IMPLEMENTED_ALPHABET_OR_CHAR = 0
     LATIN = 1
     CYRILLIC = 2
     ARABIC = 3
@@ -130,5 +130,10 @@ def detect_alphabets(text: str):
         if progress >= 99.99:
             return result
 
-    result.append((Alphabet.STRING_CONTAINS_NOT_IMPLEMENTED_ALPHABET.name, round(100 - progress, 2))
+    result.append(
+        (
+            Alphabet.NOT_IMPLEMENTED_ALPHABET_OR_CHAR.name,
+            round(100 - progress, 2),
+        )
+    )
     return result

--- a/src/textblob/blob.py
+++ b/src/textblob/blob.py
@@ -681,7 +681,7 @@ class TextBlob(BaseBlob):
 
     @property
     def alphabets(self):
-        """Return a list with tuples containing the language name and
+        """Return a list with tuples containing the alphabet name and
         percentage of presence in the text
         """
         return detect_alphabets(self.raw)

--- a/src/textblob/blob.py
+++ b/src/textblob/blob.py
@@ -681,6 +681,9 @@ class TextBlob(BaseBlob):
 
     @property
     def alphabets(self):
+        """Return a list with tuples containing the language name and
+        percentage of presence in the text
+        """
         return detect_alphabets(self.raw)
 
 

--- a/src/textblob/blob.py
+++ b/src/textblob/blob.py
@@ -41,6 +41,7 @@ from textblob.mixins import BlobComparableMixin, StringlikeMixin
 from textblob.np_extractors import FastNPExtractor
 from textblob.parsers import PatternParser
 from textblob.sentiments import PatternAnalyzer
+from textblob.alphabets_detection import detect_alphabets
 from textblob.taggers import NLTKTagger
 from textblob.tokenizers import WordTokenizer, sent_tokenize, word_tokenize
 from textblob.utils import PUNCTUATION_REGEX, lowerstrip
@@ -677,6 +678,10 @@ class TextBlob(BaseBlob):
             )
             sentence_objects.append(s)
         return sentence_objects
+
+    @property
+    def alphabets(self):
+        return detect_alphabets(self.raw)
 
 
 class Sentence(BaseBlob):

--- a/src/textblob/blob.py
+++ b/src/textblob/blob.py
@@ -26,6 +26,7 @@ from collections import defaultdict
 
 import nltk
 
+from textblob.alphabets_detection import detect_alphabets
 from textblob.base import (
     BaseNPExtractor,
     BaseParser,
@@ -41,7 +42,6 @@ from textblob.mixins import BlobComparableMixin, StringlikeMixin
 from textblob.np_extractors import FastNPExtractor
 from textblob.parsers import PatternParser
 from textblob.sentiments import PatternAnalyzer
-from textblob.alphabets_detection import detect_alphabets
 from textblob.taggers import NLTKTagger
 from textblob.tokenizers import WordTokenizer, sent_tokenize, word_tokenize
 from textblob.utils import PUNCTUATION_REGEX, lowerstrip

--- a/src/textblob/utils.py
+++ b/src/textblob/utils.py
@@ -65,3 +65,8 @@ def is_filelike(obj):
     if not callable(obj.read):
         return False
     return True
+
+
+def unicode_range(start, end):
+    """Creates char in any unicode range (used for alphabet detection."""
+    return ''.join(chr(c) for c in range(start, end + 1))

--- a/src/textblob/utils.py
+++ b/src/textblob/utils.py
@@ -69,4 +69,4 @@ def is_filelike(obj):
 
 def unicode_range(start, end):
     """Creates char in any unicode range (used for alphabet detection."""
-    return ''.join(chr(c) for c in range(start, end + 1))
+    return "".join(chr(c) for c in range(start, end + 1))

--- a/tests/test_blob.py
+++ b/tests/test_blob.py
@@ -871,14 +871,7 @@ is managed by the non-profit Python Software Foundation."""  # noqa: E501
         enum_keys = [member.name for member in Alphabet]
         for alphabet_name, percentage in alphabets_results:
             assert alphabet_name in enum_keys
-            assert (
-                percentage > 0
-                if (
-                    alphabet_name
-                    is not Alphabet.STRING_CONTAINS_NOT_IMPLEMENTED_ALPHABET.name
-                )
-                else percentage == 0
-            )
+            assert percentage > 0
             enum_keys.remove(alphabet_name)
 
         assert len(enum_keys) == 0

--- a/tests/test_blob.py
+++ b/tests/test_blob.py
@@ -11,13 +11,13 @@ import pytest
 
 import textblob as tb
 import textblob.wordnet as wn
+from textblob.alphabets_detection import Alphabet
 from textblob.classifiers import NaiveBayesClassifier
 from textblob.np_extractors import ConllExtractor, FastNPExtractor
 from textblob.parsers import PatternParser
 from textblob.sentiments import NaiveBayesAnalyzer, PatternAnalyzer
 from textblob.taggers import NLTKTagger, PatternTagger
 from textblob.tokenizers import SentenceTokenizer, WordTokenizer
-from textblob.alphabets_detection import Alphabet
 
 Synset = nltk.corpus.reader.Synset
 
@@ -271,7 +271,7 @@ is managed by the non-profit Python Software Foundation."""  # noqa: E501
         self.short = "Beautiful is better than ugly. "
         self.short_blob = tb.TextBlob(self.short)
 
-        self.detect_alphabets_text = """   
+        self.detect_alphabets_text = """
         ছথৢ৮ৡঐ৕ঀহঈঙশ৶ঁ৩ছঘঙৃষ৽ৈ৴ণয়রঽৄৈবো঒ধৈ্ঘ৺েঃৄળસ૎્૩ૂઋન૒ૺમય઄ન૧૮૳રહ૦૫ુનઋઉત૬ઇૡવ૯૫
         ૉૂ૬ૄ૗ેઌๅ๘๒ฑท๯๣ธ๾ไ๜๭ู๽๨ีีฮไ๭คญฎ๾๼๑๟๔๸ึืฆฺ๤ัฤ๭ภ๫๻ⴴⴻⵣⵏⵠⵯⴺⴵ⵿ⵐⵋⴱ⵭ⴺⴽⵙⵚ⵲ⴰⴽⵎ⵬ⵏⵇⵎ
         ⵥⵣⵎⴳⵥ⵲⵴⵵⵷ⵀⵑⵋ⵴ⵁⵊᱹᱞᱻᱭᱟᱮᱬᱳ᱐᱖ᱬᱢᱽᱬᱹᱟᱨᱠ᱕ᱩ᱗᱓ᱨᱬᱰ
@@ -871,9 +871,14 @@ is managed by the non-profit Python Software Foundation."""  # noqa: E501
         enum_keys = [member.name for member in Alphabet]
         for alphabet_name, percentage in alphabets_results:
             assert alphabet_name in enum_keys
-            assert percentage > 0 if (alphabet_name is not
-                                      Alphabet.STRING_CONTAINS_NOT_IMPLEMENTED_ALPHABET.name) \
+            assert (
+                percentage > 0
+                if (
+                    alphabet_name
+                    is not Alphabet.STRING_CONTAINS_NOT_IMPLEMENTED_ALPHABET.name
+                )
                 else percentage == 0
+            )
             enum_keys.remove(alphabet_name)
 
         assert len(enum_keys) == 0

--- a/tests/test_blob.py
+++ b/tests/test_blob.py
@@ -872,7 +872,6 @@ is managed by the non-profit Python Software Foundation."""  # noqa: E501
         for alphabet_name, percentage in alphabets_results:
             assert alphabet_name in enum_keys
             assert percentage > 0
-            print(f"{alphabet_name} - precentage: {percentage}")
             enum_keys.remove(alphabet_name)
 
         assert len(enum_keys) == 0

--- a/tests/test_blob.py
+++ b/tests/test_blob.py
@@ -17,6 +17,7 @@ from textblob.parsers import PatternParser
 from textblob.sentiments import NaiveBayesAnalyzer, PatternAnalyzer
 from textblob.taggers import NLTKTagger, PatternTagger
 from textblob.tokenizers import SentenceTokenizer, WordTokenizer
+from textblob.alphabets_detection import Alphabet
 
 Synset = nltk.corpus.reader.Synset
 
@@ -269,6 +270,24 @@ is managed by the non-profit Python Software Foundation."""  # noqa: E501
 
         self.short = "Beautiful is better than ugly. "
         self.short_blob = tb.TextBlob(self.short)
+
+        self.detect_alphabets_text = """   
+        ছথৢ৮ৡঐ৕ঀহঈঙশ৶ঁ৩ছঘঙৃষ৽ৈ৴ণয়রঽৄৈবো঒ধৈ্ঘ৺েঃৄળસ૎્૩ૂઋન૒ૺમય઄ન૧૮૳રહ૦૫ુનઋઉત૬ઇૡવ૯૫
+        ૉૂ૬ૄ૗ેઌๅ๘๒ฑท๯๣ธ๾ไ๜๭ู๽๨ีีฮไ๭คญฎ๾๼๑๟๔๸ึืฆฺ๤ัฤ๭ภ๫๻ⴴⴻⵣⵏⵠⵯⴺⴵ⵿ⵐⵋⴱ⵭ⴺⴽⵙⵚ⵲ⴰⴽⵎ⵬ⵏⵇⵎ
+        ⵥⵣⵎⴳⵥ⵲⵴⵵⵷ⵀⵑⵋ⵴ⵁⵊᱹᱞᱻᱭᱟᱮᱬᱳ᱐᱖ᱬᱢᱽᱬᱹᱟᱨᱠ᱕ᱩ᱗᱓ᱨᱬᱰ
+        ᱰᱛᱧᱭ᱐᱿ᱱᱱᱰᱯᱭᱛᱞᱣᱞೞ೵ೇ೻ೆತಔೡ಴೔಴ಣೝರಶೠ೔೚ಅ೰ೠದ೼ಃಒಿಥಳೄ೮ಃ೤ಌಔಐನಆಉzofiJ
+        UcXkBZDTGwJIRFXSEsrLMgnYVDVCrbYtCNPߥߴߡ߱ߝ߾߭ߔߌ߼߲ߪ߰߾ߍߗ߾ߧߠ߁ߍߓ߬߶߮ߡߊ߀߬ߍ߮߉ߙ߼߳߾߫߿߶߅ႯვყჺჇხზრႹლႹო჊჻ყ჌ႴზჍი჊წ჎
+        ႯჂႿჸႺზႶჼჩႥႺჾჂზႷჲӏҕѦЌҰФТїЭБЪѲҧҤЮЯӭҪӴћӃеѠЄҭнӋүҐѯҩҰӷҞӃђхгӸцඞ෮ී෴෮බ෩රූ෹බ෪තඤෑඑයඪ
+        ගඨඈඔඟඛ෿ඤඉ෵ඟඣ෧ථ෩ඐ෬ශඝ෥෨ඒຓຎ໐ຟວຳ໮໖ວ໕ຏໂຟ຤ຠງໝ໭໋໪ປິ໐ຶ໼ໃ໅໲ຜຈ໫໓໲ປ໮໋
+        ວ໐໪ऄവ൳ഥആൽൟഌനമഷ൹ഥ൙൤൦ഔർ൮൴൐ഈംിഐ൵ാ൳ഹർ൦ടഀ൞ഠൽ൤േഝ뒿텰뫨쿄뉦숴쒢넹믰푎갠큖츦좹엻혻무폛쯨껏쉑챜꿆퀨쾠렋
+        굱럹쪓껹괕숒럊궷샆쿗뼒됡쪸륍ᡒ᠜ᢕᡡᠸ᠋᠘ᢢᢿᡔᡟᢀᠻᡢᡊ᠀ᢺᢏᠡᢀᡑᡒ᠜ᢉ᠉ᢎ᠓ᡂᠹᡝᠩᢔᢦᡩᠡᡎᡕᠹᡲ᠘ⰭⱈⰍⱓⱙⰩⰯⱐⰨⰶⰛⱗⰂⰂⰄⰈⰷⰍⱔⰃⰢⰾⱂⰫⱜⱎⰰⱗⰄⰡⱝⰰⰫⰯⰑⱟⰂⰃⱚⱄ״ٰץֱַ֥ׅ֝֕֞֔֒֍֝֫רְ֢֩֞דך׳֋֮֬֜֍
+        ֧מֱ֦֬֩֩צֲַֽዤኝጧሩጧፂኪጫኜፋኹጩ፨ጪዬፆ፜ሚቝኍቿ።ኤሡኄቅሷውፋኳላሮቚሓጋፂፒሱቬሳ޷ޭޟ޵ީެޕޥ
+        ޚީވޘދޒާޖޡދފޜ޾ޒޭރޱޛރޛޱޣލ޵ޜޓޘކޡ޻ޛޤ౿ౝఱ౜ష౪ౙ౭మంూళఓౖహ౹ష౥౲ొౄఃడఙె౺౏మ౼౜ో౑ౘఢశద౹ఉఅ
+        ဳဪၷ႟ဆၼဌ၊ခဳၒၾ႒၌ၖၦၖဨဥၣၳၩညဉဌၬဒမဖ႙လၔႏၧၓ့ႛဴငၞ௄வ௳ථஆல்ൟഌനமஷ൹ഥ൙൤൦ഔർ൮൴൐ഈം
+        ഐ൵ാ൳ഹർ൦ടഀ൞ഠൽ൤േឨផុទឆឤ២ចែគ៕េៜ៿ម៭។ៃៜឱឝេឃទៗផំ៦ព៊៭ង៎ុ១៘ំ៙៿ើՇԻզփՂ֍ռԻզՖքՖ՞Իտծւ՚օրՑՊ֋՛֏֎քթծՄԴՁ֌՝ԱԵՖտճיڪ۷ڼؚ۟ڳ
+        ڶ؛؆ۻەڀۆڰڱٝڤہؚٛۯ۱ګ٭ٷ۾ةػ۳ؾ٫ـٌۢ۴ۄٜٱ۶ۮटज़ॏॻ६ऐॶ।ॕ॔॔शॄघवऄथ॔कप३ॱॢतऍस७ज़ए़॰षएःऽय़ख़ो्उਅੑਧ੐ਰੰ੓ਂਦ੕੆੝੒ਜ਼੻ਏਢ੻ੁੋਅ੏ਵ੗ੰਮ
+        ੿ੰਤਝ੸੦ੴਫੱਗ਼ਅਫ਼ਔ੔𐒈𐒈𐒮𐒚𐒍𐒪𐒃𐒅𐒓𐒯𐒁𐒩𐒓𐒠𐒛𐒇𐒪𐒝𐒟𐒧𐒩𐒆𐒌𐒠𐒥𐒢𐒆𐒘𐒎𐒓𐒪𐒆𐒪𐒒𐒀𐒫𐒗𐒊𐒣𐒒ᱧ೉"""
+        self.alphabets = tb.TextBlob(self.detect_alphabets_text)
 
     def test_init(self):
         blob = tb.TextBlob("Wow I love this place. It really rocks my socks!")
@@ -846,6 +865,18 @@ is managed by the non-profit Python Software Foundation."""  # noqa: E501
         blob = tb.TextBlob(text)
         for word, _ in blob.pos_tags:
             assert type(word.string) is str
+
+    def test_alphabets_in_text(self):
+        alphabets_results = self.alphabets.alphabets
+        enum_keys = [member.name for member in Alphabet]
+        for alphabet_name, percentage in alphabets_results:
+            assert alphabet_name in enum_keys
+            assert percentage > 0 if (alphabet_name is not
+                                      Alphabet.STRING_CONTAINS_NOT_IMPLEMENTED_ALPHABET.name) \
+                else percentage == 0
+            enum_keys.remove(alphabet_name)
+
+        assert len(enum_keys) == 0
 
 
 class WordTest(TestCase):

--- a/tests/test_blob.py
+++ b/tests/test_blob.py
@@ -872,6 +872,7 @@ is managed by the non-profit Python Software Foundation."""  # noqa: E501
         for alphabet_name, percentage in alphabets_results:
             assert alphabet_name in enum_keys
             assert percentage > 0
+            print(f"{alphabet_name} - precentage: {percentage}")
             enum_keys.remove(alphabet_name)
 
         assert len(enum_keys) == 0

--- a/tests/test_blob.py
+++ b/tests/test_blob.py
@@ -866,7 +866,7 @@ is managed by the non-profit Python Software Foundation."""  # noqa: E501
         for word, _ in blob.pos_tags:
             assert type(word.string) is str
 
-    def test_alphabets_in_text(self):
+    def test_all_alphabets_are_in_text(self):
         alphabets_results = self.alphabets.alphabets
         enum_keys = [member.name for member in Alphabet]
         for alphabet_name, percentage in alphabets_results:


### PR DESCRIPTION
With this PR I want to introduce an addition that detects alphabet chars percentage in a given text passed to `TextBlob()`.

```
>>> blob = TextBlob("hello Привет  שלום 안녕하")
>>> blob.alphabets
[('LATIN', 27.78), ('CYRILLIC', 33.33), ('HEBREW', 22.22), ('HANGUL', 16.67)]
>>> blob.alphabets[0]
('LATIN', 27.78)
>>blob.alphabets[0][1]
27.78
```

Changes:
- `alphabets_detection.py` file added in `textblob`
- `alphabets` property added to `TextBlob` class
- test `test_alphabets_in_text` added in `test_blob.py`
- section in docs quick start explaining the feature