### PR TITLE
Use custom tokenizer for words property

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -35,3 +35,4 @@ Contributors (chronological)
 - Evgeny Kemerov `@sudoguy <https://github.com/sudoguy>`_
 - Karthikeyan Singaravelan `@tirkarthi <https://github.com/tirkarthi>`_
 - John Franey `@johnfraney <https://github.com/johnfraney>`_
+- rikka0612 `@ReinerBRO <https://github.com/ReinerBRO>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+unreleased
+----------
+
+Features:
+
+- Allow custom tokenizer to be used for tokenizing words with ``.words`` (:pr:`555`).
+  Thanks :user:`ReinerBRO` for the PR.
+
 0.19.0 (2025-01-13)
 ___________________
 

--- a/src/textblob/blob.py
+++ b/src/textblob/blob.py
@@ -43,7 +43,7 @@ from textblob.parsers import PatternParser
 from textblob.sentiments import PatternAnalyzer
 from textblob.taggers import NLTKTagger
 from textblob.tokenizers import WordTokenizer, sent_tokenize, word_tokenize
-from textblob.utils import PUNCTUATION_REGEX, lowerstrip, strip_punc
+from textblob.utils import PUNCTUATION_REGEX, lowerstrip
 
 # Wordnet interface
 # NOTE: textblob.wordnet is not imported so that the wordnet corpus can be lazy-loaded
@@ -329,23 +329,17 @@ def _initialize_models(
 
 
 def _word_tokens_from_tokenizer(text, tokenizer):
-    """Tokenize text into words, excluding punctuation."""
+    """Tokenize text into words.
+
+    Preserve the historical no-punctuation behavior for the default
+    ``WordTokenizer`` path. For custom tokenizers, defer token filtering to
+    the tokenizer itself.
+    """
     if isinstance(tokenizer, WordTokenizer):
         # Keep historical behavior for the default tokenizer: tokenize by
         # sentence first, then split into word tokens.
         return word_tokenize(text, include_punc=False)
-    try:
-        return tokenizer.tokenize(text, include_punc=False)
-    except TypeError:
-        tokens = tokenizer.tokenize(text)
-        tokens_without_punc = []
-        for token in tokens:
-            stripped = strip_punc(token, all=False)
-            if not stripped:
-                continue
-            # Preserve contractions like "'s" and "n't" when possible.
-            tokens_without_punc.append(token if token.startswith("'") else stripped)
-        return tokens_without_punc
+    return tokenizer.tokenize(text)
 
 
 class BaseBlob(StringlikeMixin, BlobComparableMixin):

--- a/src/textblob/blob.py
+++ b/src/textblob/blob.py
@@ -43,7 +43,7 @@ from textblob.parsers import PatternParser
 from textblob.sentiments import PatternAnalyzer
 from textblob.taggers import NLTKTagger
 from textblob.tokenizers import WordTokenizer, sent_tokenize, word_tokenize
-from textblob.utils import PUNCTUATION_REGEX, lowerstrip
+from textblob.utils import PUNCTUATION_REGEX, lowerstrip, strip_punc
 
 # Wordnet interface
 # NOTE: textblob.wordnet is not imported so that the wordnet corpus can be lazy-loaded
@@ -328,6 +328,26 @@ def _initialize_models(
     obj.classifier = classifier
 
 
+def _word_tokens_from_tokenizer(text, tokenizer):
+    """Tokenize text into words, excluding punctuation."""
+    if isinstance(tokenizer, WordTokenizer):
+        # Keep historical behavior for the default tokenizer: tokenize by
+        # sentence first, then split into word tokens.
+        return word_tokenize(text, include_punc=False)
+    try:
+        return tokenizer.tokenize(text, include_punc=False)
+    except TypeError:
+        tokens = tokenizer.tokenize(text)
+        tokens_without_punc = []
+        for token in tokens:
+            stripped = strip_punc(token, all=False)
+            if not stripped:
+                continue
+            # Preserve contractions like "'s" and "n't" when possible.
+            tokens_without_punc.append(token if token.startswith("'") else stripped)
+        return tokens_without_punc
+
+
 class BaseBlob(StringlikeMixin, BlobComparableMixin):
     """An abstract base class that all textblob classes will inherit from.
     Includes words, POS tag, NP, and word count properties. Also includes
@@ -392,7 +412,7 @@ class BaseBlob(StringlikeMixin, BlobComparableMixin):
 
         :returns: A :class:`WordList <WordList>` of word tokens.
         """
-        return WordList(word_tokenize(self.raw, include_punc=False))
+        return WordList(_word_tokens_from_tokenizer(self.raw, self.tokenizer))
 
     @cached_property
     def tokens(self):
@@ -622,7 +642,7 @@ class TextBlob(BaseBlob):
 
         :returns: A :class:`WordList <WordList>` of word tokens.
         """
-        return WordList(word_tokenize(self.raw, include_punc=False))
+        return WordList(_word_tokens_from_tokenizer(self.raw, self.tokenizer))
 
     @property
     def raw_sentences(self):

--- a/tests/test_blob.py
+++ b/tests/test_blob.py
@@ -46,6 +46,14 @@ test = [
 classifier = NaiveBayesClassifier(train)
 
 
+class NoPunctuationWordPunctTokenizer(nltk.tokenize.api.TokenizerI):
+    def __init__(self):
+        self._tokenizer = nltk.tokenize.regexp.WordPunctTokenizer()
+
+    def tokenize(self, text):
+        return [token for token in self._tokenizer.tokenize(text) if token.isalnum()]
+
+
 class WordListTest(TestCase):
     def setUp(self):
         self.words = "Beautiful is better than ugly".split()
@@ -740,7 +748,7 @@ is managed by the non-profit Python Software Foundation."""  # noqa: E501
         assert blob.tokens == tb.WordList(["This is", "text."])
 
     def test_words_uses_custom_tokenizer(self):
-        tokenizer = nltk.tokenize.regexp.WordPunctTokenizer()
+        tokenizer = NoPunctuationWordPunctTokenizer()
         blob = tb.TextBlob("Good muffins cost $3.88\nin New York.", tokenizer=tokenizer)
         assert blob.words == tb.WordList(
             ["Good", "muffins", "cost", "3", "88", "in", "New", "York"]

--- a/tests/test_blob.py
+++ b/tests/test_blob.py
@@ -739,6 +739,13 @@ is managed by the non-profit Python Software Foundation."""  # noqa: E501
         blob = tb.TextBlob("This is\ttext.", tokenizer=tokenizer)
         assert blob.tokens == tb.WordList(["This is", "text."])
 
+    def test_words_uses_custom_tokenizer(self):
+        tokenizer = nltk.tokenize.regexp.WordPunctTokenizer()
+        blob = tb.TextBlob("Good muffins cost $3.88\nin New York.", tokenizer=tokenizer)
+        assert blob.words == tb.WordList(
+            ["Good", "muffins", "cost", "3", "88", "in", "New", "York"]
+        )
+
     def test_tokenize_method(self):
         tokenizer = nltk.tokenize.TabTokenizer()
         blob = tb.TextBlob("This is\ttext.")


### PR DESCRIPTION
## Summary
- make the words property honor the configured tokenizer instead of always using the default word tokenizer
- preserve existing behavior for the default WordTokenizer path
- add a regression test showing words follows a custom WordPunctTokenizer while still excluding punctuation

## Why
Issue #316 reports that passing tokenizer to TextBlob affects tokens but not words. This change makes behavior consistent and keeps backward compatibility for the default tokenizer path.

## Tests
- pytest tests/test_blob.py -k "words_uses_custom_tokenizer or can_use_an_different_tokenizer or tokenize_method or tokens_property" -q
- pytest tests/test_blob.py -m "not slow" -q
