### PR TITLE
chore: improve TextBlob maintenance path

### DIFF
--- a/src/textblob/utils.py
+++ b/src/textblob/utils.py
@@ -6,11 +6,12 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
+    from nltk.tree import Tree
 
 PUNCTUATION_REGEX = re.compile(f"[{re.escape(string.punctuation)}]")
 
 
-def strip_punc(s: str, all=False):
+def strip_punc(s: str, all: bool = False) -> str:
     """Removes punctuation from a string.
 
     :param s: The string.
@@ -23,7 +24,7 @@ def strip_punc(s: str, all=False):
         return s.strip().strip(string.punctuation)
 
 
-def lowerstrip(s: str, all=False):
+def lowerstrip(s: str, all: bool = False) -> str:
     """Makes text all lowercase and strips punctuation and whitespace.
 
     :param s: The string.
@@ -33,7 +34,7 @@ def lowerstrip(s: str, all=False):
     return strip_punc(s.lower().strip(), all=all)
 
 
-def tree2str(tree, concat=" "):
+def tree2str(tree: Tree, concat: str = " ") -> str:
     """Convert a nltk.tree.Tree to a string.
 
     For example:
@@ -43,8 +44,8 @@ def tree2str(tree, concat=" "):
 
 
 def filter_insignificant(
-    chunk, tag_suffixes: Iterable[str] = ("DT", "CC", "PRP$", "PRP")
-):
+    chunk: Iterable[tuple[str, str]], tag_suffixes: Iterable[str] = ("DT", "CC", "PRP$", "PRP")
+) -> list[tuple[str, str]]:
     """Filter out insignificant (word, tag) tuples from a chunk of text."""
     good: list[tuple[str, str]] = []
     for word, tag in chunk:
@@ -58,7 +59,7 @@ def filter_insignificant(
     return good
 
 
-def is_filelike(obj):
+def is_filelike(obj: object) -> bool:
     """Return whether ``obj`` is a file-like object."""
     if not hasattr(obj, "read"):
         return False

--- a/src/textblob/utils.py
+++ b/src/textblob/utils.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
+
     from nltk.tree import Tree
 
 PUNCTUATION_REGEX = re.compile(f"[{re.escape(string.punctuation)}]")
@@ -44,7 +45,8 @@ def tree2str(tree: Tree, concat: str = " ") -> str:
 
 
 def filter_insignificant(
-    chunk: Iterable[tuple[str, str]], tag_suffixes: Iterable[str] = ("DT", "CC", "PRP$", "PRP")
+    chunk: Iterable[tuple[str, str]],
+    tag_suffixes: Iterable[str] = ("DT", "CC", "PRP$", "PRP"),
 ) -> list[tuple[str, str]]:
     """Filter out insignificant (word, tag) tuples from a chunk of text."""
     good: list[tuple[str, str]] = []

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -17,8 +17,15 @@ class UtilsTests(TestCase):
     def test_strip_punc_all(self):
         assert strip_punc(self.text, all=True) == "this Has Punctuation"
 
+    def test_strip_punc_all_punctuation(self):
+        assert strip_punc("!!!", all=True) == ""
+        assert strip_punc("!!!") == ""
+
     def test_lowerstrip(self):
         assert lowerstrip(self.text) == "this. has. punctuation"
+
+    def test_lowerstrip_unicode_whitespace(self):
+        assert lowerstrip("\u2003Hello\u2003") == "hello"
 
 
 def test_is_filelike():
@@ -26,3 +33,11 @@ def test_is_filelike():
         assert is_filelike(fp)
     assert not is_filelike("notafile")
     assert not is_filelike(12.3)
+
+
+class NotAFile:
+    pass
+
+
+def test_is_filelike_missing_read():
+    assert not is_filelike(NotAFile())


### PR DESCRIPTION
Summary:
- Add explicit unit tests for edge cases in textblob.utils (e.g., strip_punc with all-punctuation input, lowerstrip with unicode whitespace, is_filelike on objects missing read attr) and tighten type annotations on the small helper functions in utils.py.
- Keep the change narrow so it is straightforward to review.

Notes:
- I kept this scoped to the relevant implementation and tests.