### PR TITLE
Fix PositiveNaiveBayesClassifier import example

### DIFF
--- a/src/textblob/classifiers.py
+++ b/src/textblob/classifiers.py
@@ -405,7 +405,7 @@ class PositiveNaiveBayesClassifier(NLTKClassifier):
     Example usage:
     ::
 
-        >>> from text.classifiers import PositiveNaiveBayesClassifier
+        >>> from textblob.classifiers import PositiveNaiveBayesClassifier
         >>> sports_sentences = ['The team dominated the game',
         ...                   'They lost the ball',
         ...                   'The game was intense',


### PR DESCRIPTION
## Summary
- update the PositiveNaiveBayesClassifier API example to import from textblob.classifiers

Fixes #347

## Testing
- git diff --check
- python3 -m py_compile src/textblob/classifiers.py